### PR TITLE
[PM-13836] Refactor IPolicyService to remove unnecessary IOrganizationService dependency

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -25,7 +25,6 @@ public class PoliciesController : Controller
 {
     private readonly IPolicyRepository _policyRepository;
     private readonly IPolicyService _policyService;
-    private readonly IOrganizationService _organizationService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IUserService _userService;
     private readonly ICurrentContext _currentContext;
@@ -36,7 +35,6 @@ public class PoliciesController : Controller
     public PoliciesController(
         IPolicyRepository policyRepository,
         IPolicyService policyService,
-        IOrganizationService organizationService,
         IOrganizationUserRepository organizationUserRepository,
         IUserService userService,
         ICurrentContext currentContext,
@@ -46,7 +44,6 @@ public class PoliciesController : Controller
     {
         _policyRepository = policyRepository;
         _policyService = policyService;
-        _organizationService = organizationService;
         _organizationUserRepository = organizationUserRepository;
         _userService = userService;
         _currentContext = currentContext;
@@ -185,7 +182,7 @@ public class PoliciesController : Controller
         }
 
         var userId = _userService.GetProperUserId(User);
-        await _policyService.SaveAsync(policy, _organizationService, userId);
+        await _policyService.SaveAsync(policy, userId);
         return new PolicyResponseModel(policy);
     }
 }

--- a/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs
@@ -6,7 +6,6 @@ using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.Context;
-using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,18 +17,15 @@ public class PoliciesController : Controller
 {
     private readonly IPolicyRepository _policyRepository;
     private readonly IPolicyService _policyService;
-    private readonly IOrganizationService _organizationService;
     private readonly ICurrentContext _currentContext;
 
     public PoliciesController(
         IPolicyRepository policyRepository,
         IPolicyService policyService,
-        IOrganizationService organizationService,
         ICurrentContext currentContext)
     {
         _policyRepository = policyRepository;
         _policyService = policyService;
-        _organizationService = organizationService;
         _currentContext = currentContext;
     }
 
@@ -96,7 +92,7 @@ public class PoliciesController : Controller
         {
             policy = model.ToPolicy(policy);
         }
-        await _policyService.SaveAsync(policy, _organizationService, null);
+        await _policyService.SaveAsync(policy, null);
         var response = new PolicyResponseModel(policy);
         return new JsonResult(response);
     }

--- a/src/Core/AdminConsole/Services/IPolicyService.cs
+++ b/src/Core/AdminConsole/Services/IPolicyService.cs
@@ -4,13 +4,12 @@ using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
-using Bit.Core.Services;
 
 namespace Bit.Core.AdminConsole.Services;
 
 public interface IPolicyService
 {
-    Task SaveAsync(Policy policy, IOrganizationService organizationService, Guid? savingUserId);
+    Task SaveAsync(Policy policy, Guid? savingUserId);
 
     /// <summary>
     /// Get the combined master password policy options for the specified user.

--- a/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
@@ -53,7 +53,7 @@ public class PolicyService : IPolicyService
         _removeOrganizationUserCommand = removeOrganizationUserCommand;
     }
 
-    public async Task SaveAsync(Policy policy, IOrganizationService organizationService, Guid? savingUserId)
+    public async Task SaveAsync(Policy policy, Guid? savingUserId)
     {
         var org = await _organizationRepository.GetByIdAsync(policy.OrganizationId);
         if (org == null)
@@ -88,7 +88,7 @@ public class PolicyService : IPolicyService
             return;
         }
 
-        await EnablePolicyAsync(policy, org, organizationService, savingUserId);
+        await EnablePolicyAsync(policy, org, savingUserId);
     }
 
     public async Task<MasterPasswordPolicyData> GetMasterPasswordPolicyForUserAsync(User user)
@@ -262,7 +262,7 @@ public class PolicyService : IPolicyService
         await _eventService.LogPolicyEventAsync(policy, EventType.Policy_Updated);
     }
 
-    private async Task EnablePolicyAsync(Policy policy, Organization org, IOrganizationService organizationService, Guid? savingUserId)
+    private async Task EnablePolicyAsync(Policy policy, Organization org, Guid? savingUserId)
     {
         var currentPolicy = await _policyRepository.GetByIdAsync(policy.Id);
         if (!currentPolicy?.Enabled ?? true)

--- a/src/Core/Auth/Services/Implementations/SsoConfigService.cs
+++ b/src/Core/Auth/Services/Implementations/SsoConfigService.cs
@@ -20,7 +20,6 @@ public class SsoConfigService : ISsoConfigService
     private readonly IPolicyService _policyService;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
-    private readonly IOrganizationService _organizationService;
     private readonly IEventService _eventService;
 
     public SsoConfigService(
@@ -29,7 +28,6 @@ public class SsoConfigService : ISsoConfigService
         IPolicyService policyService,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
-        IOrganizationService organizationService,
         IEventService eventService)
     {
         _ssoConfigRepository = ssoConfigRepository;
@@ -37,7 +35,6 @@ public class SsoConfigService : ISsoConfigService
         _policyService = policyService;
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;
-        _organizationService = organizationService;
         _eventService = eventService;
     }
 
@@ -71,20 +68,20 @@ public class SsoConfigService : ISsoConfigService
 
             singleOrgPolicy.Enabled = true;
 
-            await _policyService.SaveAsync(singleOrgPolicy, _organizationService, null);
+            await _policyService.SaveAsync(singleOrgPolicy, null);
 
             var resetPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.ResetPassword) ??
                               new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.ResetPassword, };
 
             resetPolicy.Enabled = true;
             resetPolicy.SetDataModel(new ResetPasswordDataModel { AutoEnrollEnabled = true });
-            await _policyService.SaveAsync(resetPolicy, _organizationService, null);
+            await _policyService.SaveAsync(resetPolicy, null);
 
             var ssoRequiredPolicy = await _policyRepository.GetByOrganizationIdTypeAsync(config.OrganizationId, PolicyType.RequireSso) ??
                               new Policy { OrganizationId = config.OrganizationId, Type = PolicyType.RequireSso, };
 
             ssoRequiredPolicy.Enabled = true;
-            await _policyService.SaveAsync(ssoRequiredPolicy, _organizationService, null);
+            await _policyService.SaveAsync(ssoRequiredPolicy, null);
         }
 
         await LogEventsAsync(config, oldConfig);

--- a/test/Core.Test/AdminConsole/Services/PolicyServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/PolicyServiceTests.cs
@@ -34,7 +34,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Organization not found", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -61,7 +60,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("cannot use policies", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -93,7 +91,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Single Sign-On Authentication policy is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -124,7 +121,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Maximum Vault Timeout policy is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -161,7 +157,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Key Connector is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -189,7 +184,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Single Organization policy not enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -222,7 +216,7 @@ public class PolicyServiceTests
 
         var utcNow = DateTime.UtcNow;
 
-        await sutProvider.Sut.SaveAsync(policy, Substitute.For<IOrganizationService>(), Guid.NewGuid());
+        await sutProvider.Sut.SaveAsync(policy, Guid.NewGuid());
 
         await sutProvider.GetDependency<IEventService>().Received()
             .LogPolicyEventAsync(policy, EventType.Policy_Updated);
@@ -252,7 +246,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Single Organization policy not enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -353,14 +346,13 @@ public class PolicyServiceTests
                 (orgUserDetailAdmin, false),
             });
 
-        var organizationService = Substitute.For<IOrganizationService>();
         var removeOrganizationUserCommand = sutProvider.GetDependency<IRemoveOrganizationUserCommand>();
 
         var utcNow = DateTime.UtcNow;
 
         var savingUserId = Guid.NewGuid();
 
-        await sutProvider.Sut.SaveAsync(policy, organizationService, savingUserId);
+        await sutProvider.Sut.SaveAsync(policy, savingUserId);
 
         await removeOrganizationUserCommand.Received()
             .RemoveUserAsync(policy.OrganizationId, orgUserDetailUserAcceptedWithout2FA.Id, savingUserId);
@@ -468,13 +460,12 @@ public class PolicyServiceTests
                 (orgUserDetailAdmin.UserId.Value, false),
             });
 
-        var organizationService = Substitute.For<IOrganizationService>();
         var removeOrganizationUserCommand = sutProvider.GetDependency<IRemoveOrganizationUserCommand>();
 
         var savingUserId = Guid.NewGuid();
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.SaveAsync(policy, organizationService, savingUserId));
+            () => sutProvider.Sut.SaveAsync(policy, savingUserId));
 
         Assert.Contains("Policy could not be enabled. Non-compliant members will lose access to their accounts. Identify members without two-step login from the policies column in the members page.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
 
@@ -541,13 +532,11 @@ public class PolicyServiceTests
                 (orgUserDetail.UserId.Value, false),
             });
 
-        var organizationService = Substitute.For<IOrganizationService>();
-
         var utcNow = DateTime.UtcNow;
 
         var savingUserId = Guid.NewGuid();
 
-        await sutProvider.Sut.SaveAsync(policy, organizationService, savingUserId);
+        await sutProvider.Sut.SaveAsync(policy, savingUserId);
 
         await sutProvider.GetDependency<IEventService>().Received()
             .LogPolicyEventAsync(policy, EventType.Policy_Updated);
@@ -590,7 +579,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Trusted device encryption is on and requires this policy.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -626,7 +614,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Trusted device encryption is on and requires this policy.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -659,7 +646,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Single Organization policy not enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);
@@ -692,7 +678,6 @@ public class PolicyServiceTests
 
         var badRequestException = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.SaveAsync(policy,
-                Substitute.For<IOrganizationService>(),
                 Guid.NewGuid()));
 
         Assert.Contains("Account recovery policy is enabled.", badRequestException.Message, StringComparison.OrdinalIgnoreCase);

--- a/test/Core.Test/Auth/Services/SsoConfigServiceTests.cs
+++ b/test/Core.Test/Auth/Services/SsoConfigServiceTests.cs
@@ -11,7 +11,6 @@ using Bit.Core.Auth.Services;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Core.Repositories;
-using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -342,14 +341,12 @@ public class SsoConfigServiceTests
         await sutProvider.GetDependency<IPolicyService>().Received(1)
             .SaveAsync(
                 Arg.Is<Policy>(t => t.Type == PolicyType.SingleOrg),
-                Arg.Any<IOrganizationService>(),
                 null
             );
 
         await sutProvider.GetDependency<IPolicyService>().Received(1)
             .SaveAsync(
                 Arg.Is<Policy>(t => t.Type == PolicyType.ResetPassword && t.GetDataModel<ResetPasswordDataModel>().AutoEnrollEnabled),
-                Arg.Any<IOrganizationService>(),
                 null
             );
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13836

## 📔 Objective

`IOrganizationService` is now unused in `IPolicyService.SaveAsync` so we need to remove that parameter and update any affected places such as unit tests.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request removes the `IOrganizationService` dependency from the `IPolicyService` interface and its implementations, simplifying the policy management process.

- Removed `IOrganizationService` parameter from `IPolicyService.SaveAsync` method in `/src/Core/AdminConsole/Services/IPolicyService.cs`
- Updated `PolicyService` implementation in `/src/Core/AdminConsole/Services/Implementations/PolicyService.cs` to reflect the interface change
- Modified `PoliciesController` in both `/src/Api/AdminConsole/Controllers/PoliciesController.cs` and `/src/Api/AdminConsole/Public/Controllers/PoliciesController.cs` to remove `IOrganizationService` usage
- Updated `SsoConfigService` in `/src/Core/Auth/Services/Implementations/SsoConfigService.cs` to call `_policyService.SaveAsync` without `_organizationService` parameter
- Adjusted unit tests in `/test/Core.Test/AdminConsole/Services/PolicyServiceTests.cs` and `/test/Core.Test/Auth/Services/SsoConfigServiceTests.cs` to align with the new interface

<!-- /greptile_comment -->