### PR TITLE
[PM-13834] Skip providers that have no clients during migration

### DIFF
--- a/src/Core/Billing/Migration/Models/ProviderMigrationTracker.cs
+++ b/src/Core/Billing/Migration/Models/ProviderMigrationTracker.cs
@@ -3,17 +3,14 @@
 public enum ProviderMigrationProgress
 {
     Started = 1,
-    ClientsMigrated = 2,
-    TeamsPlanConfigured = 3,
-    EnterprisePlanConfigured = 4,
-    CustomerSetup = 5,
-    SubscriptionSetup = 6,
-    CreditApplied = 7,
-    Completed = 8,
-
-    Reversing = 9,
-    ReversedClientMigrations = 10,
-    RemovedProviderPlans = 11
+    NoClients = 2,
+    ClientsMigrated = 3,
+    TeamsPlanConfigured = 4,
+    EnterprisePlanConfigured = 5,
+    CustomerSetup = 6,
+    SubscriptionSetup = 7,
+    CreditApplied = 8,
+    Completed = 9,
 }
 
 public class ProviderMigrationTracker


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-13834

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The current migration tries to process providers that have no clients, which results in an error since the migration requires organizations have Stripe entities. 

This PR skips any providers that do not have any client organizations.

![Screenshot 2024-10-18 at 9 53 28 AM](https://github.com/user-attachments/assets/cd143fa4-09cf-4c08-bcf5-754452ad55ac)


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the provider migration process to skip providers without clients, addressing an issue where such providers caused errors during migration due to missing Stripe entities.

- Added `NoClients` enum value to `ProviderMigrationProgress` in `/src/Core/Billing/Migration/Models/ProviderMigrationTracker.cs`
- Updated `ProviderMigrator.Migrate()` in `/src/Core/Billing/Migration/Services/Implementations/ProviderMigrator.cs` to check for empty client lists before proceeding
- Modified `ProviderMigrator.GetResult()` to handle the new `NoClients` case
- Removed reversal-related enum values, suggesting the migration process no longer supports rollback operations

<!-- /greptile_comment -->