### PR TITLE
[PM-13730] Return Policy object instead of NotFoundException

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -16,6 +16,7 @@ using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
+using AdminConsoleEntities = Bit.Core.AdminConsole.Entities;
 
 namespace Bit.Api.AdminConsole.Controllers;
 
@@ -61,14 +62,18 @@ public class PoliciesController : Controller
     public async Task<PolicyResponseModel> Get(string orgId, int type)
     {
         var orgIdGuid = new Guid(orgId);
+        var policy = new AdminConsoleEntities.Policy();
+        policy.Type = (PolicyType)type;
+        policy.Enabled = false;
+
         if (!await _currentContext.ManagePolicies(orgIdGuid))
         {
-            throw new NotFoundException();
+            return new PolicyResponseModel(policy);
         }
-        var policy = await _policyRepository.GetByOrganizationIdTypeAsync(orgIdGuid, (PolicyType)type);
+        policy = await _policyRepository.GetByOrganizationIdTypeAsync(orgIdGuid, (PolicyType)type);
         if (policy == null)
         {
-            throw new NotFoundException();
+            return new PolicyResponseModel(policy);
         }
 
         return new PolicyResponseModel(policy);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13730](https://bitwarden.atlassian.net/browse/PM-13730)

## 📔 Objective

This PR removes the thrown `NotFoundException` when policies are not found and returns a default `Policy` object with the same `Type` sent in the request and the `Enabled` value set to `false`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13730]: https://bitwarden.atlassian.net/browse/PM-13730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the `PoliciesController` to return a default `Policy` object instead of throwing a `NotFoundException` when a policy is not found or when the user lacks permission to manage policies.

- Modified `Get` method in `src/Api/AdminConsole/Controllers/PoliciesController.cs` to return a default `Policy` object with `Enabled` set to `false`
- Removed `NotFoundException` throw when user doesn't have permission to manage policies
- Potential impact on client-side logic that may have relied on `NotFoundException` for error handling
- Improves API consistency by providing a uniform response structure
- Consider updating API documentation to reflect this change in behavior

<!-- /greptile_comment -->