### PR TITLE
[PM-10338] Update the Organization 'Leave' endpoint to log EventType.OrganizationUser_Left

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -248,7 +248,7 @@ public class OrganizationsController : Controller
             throw new BadRequestException("Your organization's Single Sign-On settings prevent you from leaving.");
         }
 
-        await _removeOrganizationUserCommand.RemoveUserAsync(id, user.Id);
+        await _removeOrganizationUserCommand.UserLeaveAsync(id, user.Id);
     }
 
     [HttpDelete("{id}")]

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IRemoveOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IRemoveOrganizationUserCommand.cs
@@ -11,4 +11,10 @@ public interface IRemoveOrganizationUserCommand
     Task RemoveUserAsync(Guid organizationId, Guid userId);
     Task<List<Tuple<OrganizationUser, string>>> RemoveUsersAsync(Guid organizationId,
         IEnumerable<Guid> organizationUserIds, Guid? deletingUserId);
+    /// <summary>
+    /// User leaves organization.
+    /// </summary>
+    /// <param name="organizationId">Organization to leave.</param>
+    /// <param name="userId">User to leave.</param>
+    Task UserLeaveAsync(Guid organizationId, Guid userId);
 }

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs
@@ -129,7 +129,7 @@ public class OrganizationsControllerTests : IDisposable
         Assert.Contains("Your organization's Single Sign-On settings prevent you from leaving.",
             exception.Message);
 
-        await _removeOrganizationUserCommand.DidNotReceiveWithAnyArgs().RemoveUserAsync(default, default);
+        await _removeOrganizationUserCommand.DidNotReceiveWithAnyArgs().UserLeaveAsync(default, default);
     }
 
     [Theory]
@@ -160,7 +160,7 @@ public class OrganizationsControllerTests : IDisposable
 
         await _sut.Leave(orgId);
 
-        await _removeOrganizationUserCommand.Received(1).RemoveUserAsync(orgId, user.Id);
+        await _removeOrganizationUserCommand.Received(1).UserLeaveAsync(orgId, user.Id);
     }
 
     [Theory, AutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10338

## 📔 Objective

When a user leaves an organization log the event `EventType.OrganizationUser_Left`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request updates the 'Leave' endpoint in the OrganizationsController to log the event when a user leaves an organization, implementing the new UserLeaveAsync method across multiple components.

- Added `UserLeaveAsync` method to `IRemoveOrganizationUserCommand` interface in `/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IRemoveOrganizationUserCommand.cs`
- Implemented `UserLeaveAsync` in `RemoveOrganizationUserCommand` class, logging `EventType.OrganizationUser_Left` in `/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommand.cs`
- Updated `OrganizationsController` to use `UserLeaveAsync` instead of `RemoveUserAsync` in `/src/Api/AdminConsole/Controllers/OrganizationsController.cs`
- Added new test cases for `UserLeave` functionality in `/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RemoveOrganizationUserCommandTests.cs`
- Modified existing tests in `/test/Api.Test/AdminConsole/Controllers/OrganizationsControllerTests.cs` to reflect the new `UserLeaveAsync` method

<!-- /greptile_comment -->