### PR TITLE
[PM-13717] Fix legacy credit rebate for migrated MSPs

### DIFF
--- a/src/Core/Billing/Migration/Services/Implementations/ProviderMigrator.cs
+++ b/src/Core/Billing/Migration/Services/Implementations/ProviderMigrator.cs
@@ -306,21 +306,36 @@ public class ProviderMigrator(
 
         var organizationCancellationCredit = organizationCustomers.Sum(customer => customer.Balance);
 
-        var legacyOrganizations = organizations.Where(organization =>
-            organization.PlanType is
+        await stripeAdapter.CustomerBalanceTransactionCreate(provider.GatewayCustomerId,
+            new CustomerBalanceTransactionCreateOptions
+            {
+               Amount = organizationCancellationCredit,
+               Currency = "USD",
+               Description = "Unused, prorated time for client organization subscriptions."
+            });
+
+        var migrationRecords = await Task.WhenAll(organizations.Select(organization =>
+            clientOrganizationMigrationRecordRepository.GetByOrganizationId(organization.Id)));
+
+        var legacyOrganizationMigrationRecords = migrationRecords.Where(migrationRecord =>
+            migrationRecord.PlanType is
                 PlanType.EnterpriseAnnually2020 or
-                PlanType.EnterpriseMonthly2020 or
-                PlanType.TeamsAnnually2020 or
-                PlanType.TeamsMonthly2020);
+                PlanType.TeamsAnnually2020);
 
-        var legacyOrganizationCredit = legacyOrganizations.Sum(organization => organization.Seats ?? 0);
+        var legacyOrganizationCredit = legacyOrganizationMigrationRecords.Sum(migrationRecord => migrationRecord.Seats) * 12 * -100;
 
-        await stripeAdapter.CustomerUpdateAsync(provider.GatewayCustomerId, new CustomerUpdateOptions
+        if (legacyOrganizationCredit < 0)
         {
-            Balance = organizationCancellationCredit + legacyOrganizationCredit
-        });
+            await stripeAdapter.CustomerBalanceTransactionCreate(provider.GatewayCustomerId,
+                new CustomerBalanceTransactionCreateOptions
+                {
+                    Amount = legacyOrganizationCredit,
+                    Currency = "USD",
+                    Description = "1 year rebate for legacy client organizations."
+                });
+        }
 
-        logger.LogInformation("CB: Applied {Credit} credit to provider ({ProviderID})", organizationCancellationCredit, provider.Id);
+        logger.LogInformation("CB: Applied {Credit} credit to provider ({ProviderID})", organizationCancellationCredit + legacyOrganizationCredit, provider.Id);
 
         await migrationTrackerCache.UpdateTrackingStatus(provider.Id, ProviderMigrationProgress.CreditApplied);
     }

--- a/src/Core/Billing/Migration/Services/Implementations/ProviderMigrator.cs
+++ b/src/Core/Billing/Migration/Services/Implementations/ProviderMigrator.cs
@@ -309,9 +309,9 @@ public class ProviderMigrator(
         await stripeAdapter.CustomerBalanceTransactionCreate(provider.GatewayCustomerId,
             new CustomerBalanceTransactionCreateOptions
             {
-               Amount = organizationCancellationCredit,
-               Currency = "USD",
-               Description = "Unused, prorated time for client organization subscriptions."
+                Amount = organizationCancellationCredit,
+                Currency = "USD",
+                Description = "Unused, prorated time for client organization subscriptions."
             });
 
         var migrationRecords = await Task.WhenAll(organizations.Select(organization =>

--- a/src/Core/Services/IStripeAdapter.cs
+++ b/src/Core/Services/IStripeAdapter.cs
@@ -10,6 +10,8 @@ public interface IStripeAdapter
     Task<Stripe.Customer> CustomerUpdateAsync(string id, Stripe.CustomerUpdateOptions options = null);
     Task<Stripe.Customer> CustomerDeleteAsync(string id);
     Task<List<PaymentMethod>> CustomerListPaymentMethods(string id, CustomerListPaymentMethodsOptions options = null);
+    Task<CustomerBalanceTransaction> CustomerBalanceTransactionCreate(string customerId,
+        CustomerBalanceTransactionCreateOptions options);
     Task<Stripe.Subscription> SubscriptionCreateAsync(Stripe.SubscriptionCreateOptions subscriptionCreateOptions);
     Task<Stripe.Subscription> SubscriptionGetAsync(string id, Stripe.SubscriptionGetOptions options = null);
     Task<List<Stripe.Subscription>> SubscriptionListAsync(StripeSubscriptionListOptions subscriptionSearchOptions);

--- a/src/Core/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Services/Implementations/StripeAdapter.cs
@@ -18,6 +18,7 @@ public class StripeAdapter : IStripeAdapter
     private readonly Stripe.PriceService _priceService;
     private readonly Stripe.SetupIntentService _setupIntentService;
     private readonly Stripe.TestHelpers.TestClockService _testClockService;
+    private readonly CustomerBalanceTransactionService _customerBalanceTransactionService;
 
     public StripeAdapter()
     {
@@ -34,6 +35,7 @@ public class StripeAdapter : IStripeAdapter
         _priceService = new Stripe.PriceService();
         _setupIntentService = new SetupIntentService();
         _testClockService = new Stripe.TestHelpers.TestClockService();
+        _customerBalanceTransactionService = new CustomerBalanceTransactionService();
     }
 
     public Task<Stripe.Customer> CustomerCreateAsync(Stripe.CustomerCreateOptions options)
@@ -62,6 +64,10 @@ public class StripeAdapter : IStripeAdapter
         var paymentMethods = await _customerService.ListPaymentMethodsAsync(id, options);
         return paymentMethods.Data;
     }
+
+    public async Task<CustomerBalanceTransaction> CustomerBalanceTransactionCreate(string customerId,
+        CustomerBalanceTransactionCreateOptions options)
+        => await _customerBalanceTransactionService.CreateAsync(customerId, options);
 
     public Task<Stripe.Subscription> SubscriptionCreateAsync(Stripe.SubscriptionCreateOptions options)
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-13717

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR fixes 2 issues:
1. Legacy credit rebates were originally not working because they were checking the migrating organization's plan type. However, by the time we're applying credit, the organization has already had their plan type changed to one of the Consolidated Billing-supported types in order for the organization to work in the platform. As such, I had to use the organization's migration record to determine their legacy rebate.
2. The credit for the organization's cancellation proration and legacy rebate were being applied in the same request. I broke those up into two different requests and added a description to the credit application so it's easier for CS to track.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request addresses issues with legacy credit rebates for migrated MSPs in the billing system. Key changes include:

- Modified `ApplyCreditAsync` in `ProviderMigrator.cs` to correctly handle legacy credit rebates
- Separated cancellation proration and legacy rebate credit applications for clarity
- Added `CustomerBalanceTransactionCreate` method to `IStripeAdapter` interface
- Implemented `CustomerBalanceTransactionCreate` in `StripeAdapter` class using Stripe's API
- Introduced `CustomerBalanceTransactionService` in `StripeAdapter` for improved balance management

These changes enhance the accuracy and transparency of credit applications for migrated MSP organizations, fixing issues with legacy plan detection and credit allocation.

<!-- /greptile_comment -->