### PR TITLE
[PM-13706] Add repository + stored procedures for private key regeneration

### DIFF
--- a/src/Core/KeyManagement/Models/Data/UserAsymmetricKeys.cs
+++ b/src/Core/KeyManagement/Models/Data/UserAsymmetricKeys.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+namespace Bit.Core.KeyManagement.Models.Data;
+
+public class UserAsymmetricKeys
+{
+    public Guid UserId { get; set; }
+    public required string PublicKey { get; set; }
+    public required string UserKeyEncryptedPrivateKey { get; set; }
+}

--- a/src/Core/KeyManagement/Repositories/IUserAsymmetricKeysRepository.cs
+++ b/src/Core/KeyManagement/Repositories/IUserAsymmetricKeysRepository.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+using Bit.Core.KeyManagement.Models.Data;
+
+namespace Bit.Core.KeyManagement.Repositories;
+
+public interface IUserAsymmetricKeysRepository
+{
+    Task RegenerateUserAsymmetricKeysAsync(UserAsymmetricKeys userAsymmetricKeys);
+}

--- a/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
+++ b/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Billing.Repositories;
+using Bit.Core.KeyManagement.Repositories;
 using Bit.Core.NotificationCenter.Repositories;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Repositories;
@@ -9,6 +10,7 @@ using Bit.Core.Vault.Repositories;
 using Bit.Infrastructure.Dapper.AdminConsole.Repositories;
 using Bit.Infrastructure.Dapper.Auth.Repositories;
 using Bit.Infrastructure.Dapper.Billing.Repositories;
+using Bit.Infrastructure.Dapper.KeyManagement.Repositories;
 using Bit.Infrastructure.Dapper.NotificationCenter.Repositories;
 using Bit.Infrastructure.Dapper.Repositories;
 using Bit.Infrastructure.Dapper.SecretsManager.Repositories;
@@ -58,6 +60,7 @@ public static class DapperServiceCollectionExtensions
         services.AddSingleton<INotificationStatusRepository, NotificationStatusRepository>();
         services
             .AddSingleton<IClientOrganizationMigrationRecordRepository, ClientOrganizationMigrationRecordRepository>();
+        services.AddSingleton<IUserAsymmetricKeysRepository, UserAsymmetricKeysRepository>();
 
         if (selfHosted)
         {

--- a/src/Infrastructure.Dapper/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
+++ b/src/Infrastructure.Dapper/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using System.Data;
+using Bit.Core.KeyManagement.Models.Data;
+using Bit.Core.KeyManagement.Repositories;
+using Bit.Core.Settings;
+using Bit.Infrastructure.Dapper.Repositories;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+namespace Bit.Infrastructure.Dapper.KeyManagement.Repositories;
+
+public class UserAsymmetricKeysRepository : BaseRepository, IUserAsymmetricKeysRepository
+{
+    public UserAsymmetricKeysRepository(GlobalSettings globalSettings)
+        : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
+    {
+    }
+
+    public UserAsymmetricKeysRepository(string connectionString, string readOnlyConnectionString) : base(
+        connectionString, readOnlyConnectionString)
+    {
+    }
+
+    public async Task RegenerateUserAsymmetricKeysAsync(UserAsymmetricKeys userAsymmetricKeys)
+    {
+        await using var connection = new SqlConnection(ConnectionString);
+
+        await connection.ExecuteAsync("[dbo].[UserAsymmetricKeys_Regenerate]",
+            userAsymmetricKeys, commandType: CommandType.StoredProcedure);
+    }
+}

--- a/src/Infrastructure.Dapper/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
+++ b/src/Infrastructure.Dapper/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
@@ -26,6 +26,11 @@ public class UserAsymmetricKeysRepository : BaseRepository, IUserAsymmetricKeysR
         await using var connection = new SqlConnection(ConnectionString);
 
         await connection.ExecuteAsync("[dbo].[UserAsymmetricKeys_Regenerate]",
-            userAsymmetricKeys, commandType: CommandType.StoredProcedure);
+            new
+            {
+                userAsymmetricKeys.UserId,
+                userAsymmetricKeys.PublicKey,
+                PrivateKey = userAsymmetricKeys.UserKeyEncryptedPrivateKey
+            }, commandType: CommandType.StoredProcedure);
     }
 }

--- a/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Billing.Repositories;
 using Bit.Core.Enums;
+using Bit.Core.KeyManagement.Repositories;
 using Bit.Core.NotificationCenter.Repositories;
 using Bit.Core.Repositories;
 using Bit.Core.SecretsManager.Repositories;
@@ -10,6 +11,7 @@ using Bit.Core.Vault.Repositories;
 using Bit.Infrastructure.EntityFramework.AdminConsole.Repositories;
 using Bit.Infrastructure.EntityFramework.Auth.Repositories;
 using Bit.Infrastructure.EntityFramework.Billing.Repositories;
+using Bit.Infrastructure.EntityFramework.KeyManagement.Repositories;
 using Bit.Infrastructure.EntityFramework.NotificationCenter.Repositories;
 using Bit.Infrastructure.EntityFramework.Repositories;
 using Bit.Infrastructure.EntityFramework.SecretsManager.Repositories;
@@ -95,6 +97,7 @@ public static class EntityFrameworkServiceCollectionExtensions
         services.AddSingleton<INotificationStatusRepository, NotificationStatusRepository>();
         services
             .AddSingleton<IClientOrganizationMigrationRecordRepository, ClientOrganizationMigrationRecordRepository>();
+        services.AddSingleton<IUserAsymmetricKeysRepository, UserAsymmetricKeysRepository>();
 
         if (selfHosted)
         {

--- a/src/Infrastructure.EntityFramework/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
+++ b/src/Infrastructure.EntityFramework/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+using AutoMapper;
+using Bit.Core.KeyManagement.Models.Data;
+using Bit.Core.KeyManagement.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Infrastructure.EntityFramework.KeyManagement.Repositories;
+
+public class UserAsymmetricKeysRepository : BaseEntityFrameworkRepository, IUserAsymmetricKeysRepository
+{
+    public UserAsymmetricKeysRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper) : base(
+        serviceScopeFactory,
+        mapper)
+    {
+    }
+
+    public async Task RegenerateUserAsymmetricKeysAsync(UserAsymmetricKeys userAsymmetricKeys)
+    {
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var dbContext = GetDatabaseContext(scope);
+
+        var entity = await dbContext.Users.FindAsync(userAsymmetricKeys.UserId);
+        if (entity != null)
+        {
+            entity.PublicKey = userAsymmetricKeys.PublicKey;
+            entity.PrivateKey = userAsymmetricKeys.UserKeyEncryptedPrivateKey;
+            await dbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Infrastructure.EntityFramework/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
+++ b/src/Infrastructure.EntityFramework/KeyManagement/Repositories/UserAsymmetricKeysRepository.cs
@@ -23,8 +23,11 @@ public class UserAsymmetricKeysRepository : BaseEntityFrameworkRepository, IUser
         var entity = await dbContext.Users.FindAsync(userAsymmetricKeys.UserId);
         if (entity != null)
         {
+            var utcNow = DateTime.UtcNow;
             entity.PublicKey = userAsymmetricKeys.PublicKey;
             entity.PrivateKey = userAsymmetricKeys.UserKeyEncryptedPrivateKey;
+            entity.RevisionDate = utcNow;
+            entity.AccountRevisionDate = utcNow;
             await dbContext.SaveChangesAsync();
         }
     }

--- a/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
+++ b/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
@@ -5,9 +5,12 @@ CREATE PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
 AS
 BEGIN
     SET NOCOUNT ON
+    DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
 
     UPDATE [dbo].[User]
     SET [PublicKey] = @PublicKey,
-        [PrivateKey] = @PrivateKey
+        [PrivateKey] = @PrivateKey,
+        [RevisionDate] = @UtcNow,
+        [AccountRevisionDate] = @UtcNow
     WHERE [Id] = @UserId
 END

--- a/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
+++ b/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
@@ -1,17 +1,13 @@
 CREATE PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
-    @UserId UNIQUEIDENTIFIER OUTPUT,
+    @UserId UNIQUEIDENTIFIER,
     @PublicKey VARCHAR(MAX),
     @PrivateKey VARCHAR(MAX)
 AS
 BEGIN
     SET NOCOUNT ON
 
-    BEGIN TRANSACTION UserAsymmetricKeys_Regenerate
-
     UPDATE [dbo].[User]
     SET [PublicKey] = @PublicKey,
         [PrivateKey] = @PrivateKey
     WHERE [Id] = @UserId
-
-    COMMIT TRANSACTION UserAsymmetricKeys_Regenerate
 END

--- a/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
+++ b/src/Sql/KeyManagement/dbo/Stored Procedures/UserAsymmetricKeys_Regenerate.sql
@@ -1,0 +1,17 @@
+CREATE PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
+    @UserId UNIQUEIDENTIFIER OUTPUT,
+    @PublicKey VARCHAR(MAX),
+    @PrivateKey VARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    BEGIN TRANSACTION UserAsymmetricKeys_Regenerate
+
+    UPDATE [dbo].[User]
+    SET [PublicKey] = @PublicKey,
+        [PrivateKey] = @PrivateKey
+    WHERE [Id] = @UserId
+
+    COMMIT TRANSACTION UserAsymmetricKeys_Regenerate
+END

--- a/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
+++ b/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
@@ -1,0 +1,13 @@
+CREATE OR ALTER PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
+    @UserId UNIQUEIDENTIFIER OUTPUT,
+    @PublicKey VARCHAR(MAX),
+    @PrivateKey VARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    UPDATE [dbo].[User]
+    SET [PublicKey] = @PublicKey,
+        [PrivateKey] = @PrivateKey
+    WHERE [Id] = @UserId
+END

--- a/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
+++ b/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
@@ -1,5 +1,5 @@
 CREATE OR ALTER PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
-    @UserId UNIQUEIDENTIFIER OUTPUT,
+    @UserId UNIQUEIDENTIFIER,
     @PublicKey VARCHAR(MAX),
     @PrivateKey VARCHAR(MAX)
 AS

--- a/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
+++ b/util/Migrator/DbScripts/2024-10-15_01_AddUserAsymmetricKeysRegenerate.sql
@@ -5,9 +5,12 @@ CREATE OR ALTER PROCEDURE [dbo].[UserAsymmetricKeys_Regenerate]
 AS
 BEGIN
     SET NOCOUNT ON
+    DECLARE @UtcNow DATETIME2(7) = GETUTCDATE();
 
     UPDATE [dbo].[User]
     SET [PublicKey] = @PublicKey,
-        [PrivateKey] = @PrivateKey
+        [PrivateKey] = @PrivateKey,
+        [RevisionDate] = @UtcNow,
+        [AccountRevisionDate] = @UtcNow
     WHERE [Id] = @UserId
 END


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-13706

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The purpose of this PR is to add the database stored procedure and repository layer for the private key regeneration project.

This initial phase will only target users not in organizations and without emergency access setup.
In future PRs, the database operations will expand to handle these cases.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request introduces a new repository and stored procedures for regenerating user asymmetric keys, focusing on users not in organizations and without emergency access setup.

- Added `UserAsymmetricKeys` model in `/src/Core/KeyManagement/Models/Data/UserAsymmetricKeys.cs` with properties for UserId, PublicKey, and UserKeyEncryptedPrivateKey
- Implemented `IUserAsymmetricKeysRepository` interface and its Dapper and Entity Framework implementations for key regeneration
- Created stored procedure `UserAsymmetricKeys_Regenerate` in SQL and migration scripts to update user keys and revision dates
- Updated service collection extensions in both Dapper and Entity Framework to register the new repository
- Added `RegenerateUserAsymmetricKeysAsync` method in repositories to execute key regeneration logic

<!-- /greptile_comment -->