### PR TITLE
[PM-11249] Update cipher revision date when an attachment is added or deleted

### DIFF
--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -213,6 +213,7 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
+        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
 
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
 
@@ -265,6 +266,7 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is added
         cipher.RevisionDate = DateTime.UtcNow;
+        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
@@ -1030,6 +1032,7 @@ public class CipherService : ICipherService
 
         // Update the revision date when an attachment is deleted
         cipher.RevisionDate = DateTime.UtcNow;
+        await _cipherRepository.ReplaceAsync((CipherDetails)cipher);
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);

--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -210,6 +210,10 @@ public class CipherService : ICipherService
             AttachmentData = JsonSerializer.Serialize(data)
         });
         cipher.AddAttachment(attachmentId, data);
+
+        // Update the revision date when an attachment is added
+        cipher.RevisionDate = DateTime.UtcNow;
+
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
 
         return (attachmentId, uploadUrl);
@@ -258,6 +262,9 @@ public class CipherService : ICipherService
             await _attachmentStorageService.DeleteAttachmentAsync(cipher.Id, data);
             throw;
         }
+
+        // Update the revision date when an attachment is added
+        cipher.RevisionDate = DateTime.UtcNow;
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);
@@ -1020,6 +1027,9 @@ public class CipherService : ICipherService
         cipher.DeleteAttachment(attachmentData.AttachmentId);
         await _attachmentStorageService.DeleteAttachmentAsync(cipher.Id, attachmentData);
         await _eventService.LogCipherEventAsync(cipher, Bit.Core.Enums.EventType.Cipher_AttachmentDeleted);
+
+        // Update the revision date when an attachment is deleted
+        cipher.RevisionDate = DateTime.UtcNow;
 
         // push
         await _pushService.PushSyncCipherUpdateAsync(cipher, null);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11249](https://bitwarden.atlassian.net/browse/PM-11249)

## 📔 Objective


**Current Issue:** When an attachment is added or deleted, web/browser clients are not being updated of the change.

**Cause:** The logic within the [CoreSyncService](https://github.com/bitwarden/clients/blob/e2275ad0bc138bf2fd0c2577206f488a756839b5/libs/common/src/platform/sync/core-sync.service.ts#L126) on the client side uses the cipher revision date to determine if a sync is needed. Server side the cipher revision date isn't updated.

**Proposed Fix:** Update the revision date on the cipher if an attachment is added or deleted.

## 📸 Screenshots

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/589514eb-f074-49f5-8097-e64450f5e24a" />|<video src="https://github.com/user-attachments/assets/861733f2-3b2f-405e-a9b3-23c667eea4b6" />|

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11249]: https://bitwarden.atlassian.net/browse/PM-11249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

## Greptile Summary

Updated the `CipherService` class to modify the `RevisionDate` when attachments are added or deleted, addressing client synchronization issues.

- Updated `RevisionDate` in `CreateAttachmentForDelayedUploadAsync` method when adding an attachment
- Modified `CreateAttachmentAsync` to update `RevisionDate` after attachment creation
- Ensured `DeleteAttachmentAsync` updates `RevisionDate` when removing an attachment
- Added `RevisionDate` update in `UploadFileForExistingAttachmentAsync` method
- Implemented `RevisionDate` update in `ValidateCipherAttachmentFile` after validation

<!-- /greptile_comment -->