### PR TITLE
[PM-12290] Add self-host eligibility to organization metadata

### DIFF
--- a/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
+++ b/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs
@@ -3,8 +3,11 @@
 namespace Bit.Api.Billing.Models.Responses;
 
 public record OrganizationMetadataResponse(
+    bool IsEligibleForSelfHost,
     bool IsOnSecretsManagerStandalone)
 {
     public static OrganizationMetadataResponse From(OrganizationMetadata metadata)
-        => new(metadata.IsOnSecretsManagerStandalone);
+        => new(
+            metadata.IsEligibleForSelfHost,
+            metadata.IsOnSecretsManagerStandalone);
 }

--- a/src/Core/Billing/Models/OrganizationMetadata.cs
+++ b/src/Core/Billing/Models/OrganizationMetadata.cs
@@ -1,8 +1,10 @@
 ﻿namespace Bit.Core.Billing.Models;
 
 public record OrganizationMetadata(
+    bool IsEligibleForSelfHost,
     bool IsOnSecretsManagerStandalone)
 {
     public static OrganizationMetadata Default() => new(
-        IsOnSecretsManagerStandalone: default);
+        IsEligibleForSelfHost: false,
+        IsOnSecretsManagerStandalone: false);
 }

--- a/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs
@@ -52,7 +52,7 @@ public class OrganizationBillingControllerTests
     {
         sutProvider.GetDependency<ICurrentContext>().AccessMembersTab(organizationId).Returns(true);
         sutProvider.GetDependency<IOrganizationBillingService>().GetMetadata(organizationId)
-            .Returns(new OrganizationMetadata(true));
+            .Returns(new OrganizationMetadata(true, true));
 
         var result = await sutProvider.Sut.GetMetadataAsync(organizationId);
 
@@ -60,6 +60,7 @@ public class OrganizationBillingControllerTests
 
         var organizationMetadataResponse = ((Ok<OrganizationMetadataResponse>)result).Value;
 
+        Assert.True(organizationMetadataResponse.IsEligibleForSelfHost);
         Assert.True(organizationMetadataResponse.IsOnSecretsManagerStandalone);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-12290

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This PR adds a field to the `OrganizationMetadata` record that indicates whether an organization is eligible for self-host and adds the correct value for that field to the Organization Billing Metadata response.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request adds a new field `IsEligibleForSelfHost` to the organization metadata, enhancing the billing system's capability to track self-hosting eligibility for organizations.

- Added `IsEligibleForSelfHost` field to `OrganizationMetadata` and `OrganizationMetadataResponse` records in `/src/Core/Billing/Models/OrganizationMetadata.cs` and `/src/Api/Billing/Models/Responses/OrganizationMetadataResponse.cs`
- Implemented `IsEligibleForSelfHost` method in `OrganizationBillingService` (/src/Core/Billing/Services/Implementations/OrganizationBillingService.cs) to calculate eligibility
- Updated `GetMetadata` method in `OrganizationBillingService` to include the new field
- Modified `OrganizationBillingControllerTests` (/test/Api.Test/Billing/Controllers/OrganizationBillingControllerTests.cs) to cover the new field in relevant test cases

<!-- /greptile_comment -->