### PR TITLE
Return Non-Zero Exit Code On Failure

### DIFF
--- a/util/MsSqlMigratorUtility/Program.cs
+++ b/util/MsSqlMigratorUtility/Program.cs
@@ -9,7 +9,7 @@ internal class Program
     }
 
     [DefaultCommand]
-    public void Execute(
+    public int Execute(
         [Operand(Description = "Database connection string")]
         string databaseConnectionString,
         [Option('r', "repeatable", Description = "Mark scripts as repeatable")]
@@ -18,7 +18,7 @@ internal class Program
         string folderName = MigratorConstants.DefaultMigrationsFolderName,
         [Option('d', "dry-run", Description = "Print the scripts that will be applied without actually executing them")]
         bool dryRun = false
-        ) => MigrateDatabase(databaseConnectionString, repeatable, folderName, dryRun);
+        ) => MigrateDatabase(databaseConnectionString, repeatable, folderName, dryRun) ? 0 : 1;
 
     private static bool MigrateDatabase(string databaseConnectionString,
         bool repeatable = false, string folderName = "", bool dryRun = false)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Return a non-zero exit code on failure so that github actions will mark a step that calls this project a failure if migrations could not be applied.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the MsSqlMigratorUtility to return a non-zero exit code on failure, enabling GitHub Actions to detect migration failures accurately.

- Modified `Execute` method in `/util/MsSqlMigratorUtility/Program.cs` to return an integer (0 for success, 1 for failure)
- Ensures CI/CD pipelines can reflect the success or failure of database migration operations
- Improves error detection in automated workflows without changing core migration functionality

<!-- /greptile_comment -->