### PR TITLE
Turn on `LimitCollectionCreationDeletionSplit` for self host

### DIFF
--- a/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/_ViewInformation.cshtml
@@ -1,4 +1,6 @@
-﻿@model OrganizationViewModel
+@inject Bit.Core.Services.IFeatureService FeatureService
+@model OrganizationViewModel
+
 <dl class="row">
     <dt class="col-sm-4 col-lg-3">Id</dt>
     <dd id="org-id" class="col-sm-8 col-lg-9"><code>@Model.Organization.Id</code></dd>
@@ -53,8 +55,19 @@
     <dt class="col-sm-4 col-lg-3">Administrators manage all collections</dt>
     <dd id="pm-manage-collections" class="col-sm-8 col-lg-9">@(Model.Organization.AllowAdminAccessToAllCollectionItems ? "On" : "Off")</dd>
 
-    <dt class="col-sm-4 col-lg-3">Limit collection creation to administrators</dt>
-    <dd id="pm-collection-creation" class="col-sm-8 col-lg-9">@(Model.Organization.LimitCollectionCreationDeletion ? "On" : "Off")</dd>
+    @if (!FeatureService.IsEnabled(Bit.Core.FeatureFlagKeys.LimitCollectionCreationDeletionSplit))
+    {
+      <dt class="col-sm-4 col-lg-3">Limit collection creation to administrators</dt>
+      <dd id="pm-collection-creation" class="col-sm-8 col-lg-9">@(Model.Organization.LimitCollectionCreationDeletion ? "On" : "Off")</dd>
+    }
+    else
+    {
+      <dt class="col-sm-4 col-lg-3">Limit collection creation to administrators</dt>
+      <dd id="pm-collection-creation" class="col-sm-8 col-lg-9">@(Model.Organization.LimitCollectionCreation ? "On" : "Off")</dd>
+
+      <dt class="col-sm-4 col-lg-3">Limit collection deletion to administrators</dt>
+      <dd id="pm-collection-deletion" class="col-sm-8 col-lg-9">@(Model.Organization.LimitCollectionDeletion ? "On" : "Off")</dd>
+    }
 </dl>
 
 <h2>Secrets Manager</h2>

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -514,7 +514,6 @@ public class OrganizationsController : Controller
     }
 
     [HttpPut("{id}/collection-management")]
-    [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<OrganizationResponseModel> PutCollectionManagement(Guid id, [FromBody] OrganizationCollectionManagementUpdateRequestModel model)
     {
         var organization = await _organizationRepository.GetByIdAsync(id);

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -516,6 +516,14 @@ public class OrganizationsController : Controller
     [HttpPut("{id}/collection-management")]
     public async Task<OrganizationResponseModel> PutCollectionManagement(Guid id, [FromBody] OrganizationCollectionManagementUpdateRequestModel model)
     {
+        if (
+          _globalSettings.SelfHosted &&
+          !_featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit)
+        )
+        {
+            throw new BadRequestException("Only allowed when not self hosted.");
+        }
+
         var organization = await _organizationRepository.GetByIdAsync(id);
         if (organization == null)
         {

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -55,6 +55,9 @@ public class OrganizationResponseModel : ResponseModel
         SmServiceAccounts = organization.SmServiceAccounts;
         MaxAutoscaleSmSeats = organization.MaxAutoscaleSmSeats;
         MaxAutoscaleSmServiceAccounts = organization.MaxAutoscaleSmServiceAccounts;
+        LimitCollectionCreation = organization.LimitCollectionCreation;
+        LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        // Deperectated: https://bitwarden.atlassian.net/browse/PM-10863
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
     }
@@ -98,6 +101,9 @@ public class OrganizationResponseModel : ResponseModel
     public int? SmServiceAccounts { get; set; }
     public int? MaxAutoscaleSmSeats { get; set; }
     public int? MaxAutoscaleSmServiceAccounts { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    // Deperectated: https://bitwarden.atlassian.net/browse/PM-10863
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -57,7 +57,7 @@ public class OrganizationResponseModel : ResponseModel
         MaxAutoscaleSmServiceAccounts = organization.MaxAutoscaleSmServiceAccounts;
         LimitCollectionCreation = organization.LimitCollectionCreation;
         LimitCollectionDeletion = organization.LimitCollectionDeletion;
-        // Deperectated: https://bitwarden.atlassian.net/browse/PM-10863
+        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
     }

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -62,6 +62,9 @@ public class ProfileOrganizationResponseModel : ResponseModel
         FamilySponsorshipToDelete = organization.FamilySponsorshipToDelete;
         FamilySponsorshipValidUntil = organization.FamilySponsorshipValidUntil;
         AccessSecretsManager = organization.AccessSecretsManager;
+        LimitCollectionCreation = organization.LimitCollectionCreation;
+        LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
 
@@ -120,6 +123,9 @@ public class ProfileOrganizationResponseModel : ResponseModel
     public DateTime? FamilySponsorshipValidUntil { get; set; }
     public bool? FamilySponsorshipToDelete { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 }

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -44,6 +44,9 @@ public class ProfileProviderOrganizationResponseModel : ProfileOrganizationRespo
         ProviderId = organization.ProviderId;
         ProviderName = organization.ProviderName;
         ProductTierType = StaticStore.GetPlan(organization.PlanType).ProductTier;
+        LimitCollectionCreation = organization.LimitCollectionCreation;
+        LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        // https://bitwarden.atlassian.net/browse/PM-10863
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
     }

--- a/src/Api/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
+++ b/src/Api/Models/Request/Organizations/OrganizationCollectionManagementUpdateRequestModel.cs
@@ -4,11 +4,17 @@ namespace Bit.Api.Models.Request.Organizations;
 
 public class OrganizationCollectionManagementUpdateRequestModel
 {
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
     public bool LimitCreateDeleteOwnerAdmin { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 
     public virtual Organization ToOrganization(Organization existingOrganization)
     {
+        existingOrganization.LimitCollectionCreation = LimitCollectionCreation;
+        existingOrganization.LimitCollectionDeletion = LimitCollectionDeletion;
+        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
         existingOrganization.LimitCollectionCreationDeletion = LimitCreateDeleteOwnerAdmin;
         existingOrganization.AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems;
         return existingOrganization;

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -126,9 +126,9 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
 
         var organizationAbility = await GetOrganizationAbilityAsync(org);
 
-        var limitCollectionCreationEnabled = !(_featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit)
-            ? organizationAbility is { LimitCollectionCreation: false }
-            : organizationAbility is { LimitCollectionCreationDeletion: false });
+        var limitCollectionCreationEnabled = _featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit)
+            ? organizationAbility is { LimitCollectionCreation: true }
+            : organizationAbility is { LimitCollectionCreationDeletion: true };
 
         // If the limit collection management setting is disabled, allow any user to create collections
         if (!limitCollectionCreationEnabled)
@@ -264,9 +264,9 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
         // If LimitCollectionCreationDeletion is true, only Owners and Admins can delete collections they manage
         var organizationAbility = await GetOrganizationAbilityAsync(org);
 
-        var limitCollectionDeletionEnabled = !(_featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit)
-            ? organizationAbility is { LimitCollectionDeletion: false }
-            : organizationAbility is { LimitCollectionCreationDeletion: false });
+        var limitCollectionDeletionEnabled = _featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit)
+            ? organizationAbility is { LimitCollectionDeletion: true }
+            : organizationAbility is { LimitCollectionCreationDeletion: true };
 
         var canDeleteManagedCollections =
             !limitCollectionDeletionEnabled ||

--- a/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
+++ b/src/Api/Vault/AuthorizationHandlers/Collections/BulkCollectionAuthorizationHandler.cs
@@ -273,7 +273,7 @@ public class BulkCollectionAuthorizationHandler : BulkAuthorizationHandler<BulkC
             var limitCollectionDeletionEnabled = await GetOrganizationAbilityAsync(org) is { LimitCollectionDeletion: true };
             var userIsOrgOwnerOrAdmin = org is { Type: OrganizationUserType.Owner or OrganizationUserType.Admin };
             // If the limit collection management setting is disabled, allow any user to delete collections
-            if (userIsMemberOfOrg && (!limitCollectionDeletionEnabled || userIsOrgOwnerOrAdmin))
+            if (userIsMemberOfOrg && (!limitCollectionDeletionEnabled || userIsOrgOwnerOrAdmin) && await CanManageCollectionsAsync(resources, org))
             {
                 return true;
             }

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -7,6 +7,7 @@ using Bit.Core.Billing.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Business;
+using Bit.Core.Services;
 using Bit.Core.Tools.Entities;
 using Bit.Core.Utilities;
 
@@ -278,7 +279,7 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
         return providers[provider];
     }
 
-    public void UpdateFromLicense(OrganizationLicense license)
+    public void UpdateFromLicense(OrganizationLicense license, IFeatureService featureService)
     {
         // The following properties are intentionally excluded from being updated:
         // - Id - self-hosted org will have its own unique Guid
@@ -313,6 +314,11 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
         UseSecretsManager = license.UseSecretsManager;
         SmSeats = license.SmSeats;
         SmServiceAccounts = license.SmServiceAccounts;
-        AllowAdminAccessToAllCollectionItems = license.AllowAdminAccessToAllCollectionItems;
+
+        if (!featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit))
+        {
+            LimitCollectionCreationDeletion = license.LimitCollectionCreationDeletion;
+            AllowAdminAccessToAllCollectionItems = license.AllowAdminAccessToAllCollectionItems;
+        }
     }
 }

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -95,7 +95,18 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
     /// </summary>
     public bool LimitCollectionCreation { get; set; }
     public bool LimitCollectionDeletion { get; set; }
-    public bool LimitCollectionCreationDeletion { get; set; }
+    // Deprecated by https://bitwarden.atlassian.net/browse/PM-10863. This
+    // was replaced with `LimitCollectionCreation` and
+    // `LimitCollectionDeletion`.
+    public bool LimitCollectionCreationDeletion
+    {
+        get => LimitCollectionCreation || LimitCollectionDeletion;
+        set
+        {
+            LimitCollectionCreation = value;
+            LimitCollectionDeletion = value;
+        }
+    }
 
     /// <summary>
     /// If set to true, admins, owners, and some custom users can read/write all collections and items in the Admin Console.

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -313,7 +313,6 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
         UseSecretsManager = license.UseSecretsManager;
         SmSeats = license.SmSeats;
         SmServiceAccounts = license.SmServiceAccounts;
-        LimitCollectionCreationDeletion = license.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = license.AllowAdminAccessToAllCollectionItems;
     }
 }

--- a/src/Core/AdminConsole/Entities/Organization.cs
+++ b/src/Core/AdminConsole/Entities/Organization.cs
@@ -93,6 +93,8 @@ public class Organization : ITableObject<Guid>, IStorableSubscriber, IRevisable,
     /// If set to false, any organization member can create a collection, and any member can delete a collection that
     /// they have Can Manage permissions for.
     /// </summary>
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
     public bool LimitCollectionCreationDeletion { get; set; }
 
     /// <summary>

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationAbility.cs
@@ -21,6 +21,9 @@ public class OrganizationAbility
         UseResetPassword = organization.UseResetPassword;
         UseCustomPermissions = organization.UseCustomPermissions;
         UsePolicies = organization.UsePolicies;
+        LimitCollectionCreation = organization.LimitCollectionCreation;
+        LimitCollectionDeletion = organization.LimitCollectionDeletion;
+        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
         LimitCollectionCreationDeletion = organization.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = organization.AllowAdminAccessToAllCollectionItems;
     }
@@ -37,6 +40,9 @@ public class OrganizationAbility
     public bool UseResetPassword { get; set; }
     public bool UseCustomPermissions { get; set; }
     public bool UsePolicies { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/OrganizationUsers/OrganizationUserOrganizationDetails.cs
@@ -54,6 +54,9 @@ public class OrganizationUserOrganizationDetails
     public bool UsePasswordManager { get; set; }
     public int? SmSeats { get; set; }
     public int? SmServiceAccounts { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
+    // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/SelfHostedOrganizationDetails.cs
@@ -144,6 +144,9 @@ public class SelfHostedOrganizationDetails : Organization
             RevisionDate = RevisionDate,
             MaxAutoscaleSeats = MaxAutoscaleSeats,
             OwnersNotifiedOfAutoscaling = OwnersNotifiedOfAutoscaling,
+            LimitCollectionCreation = LimitCollectionCreation,
+            LimitCollectionDeletion = LimitCollectionDeletion,
+            // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
             LimitCollectionCreationDeletion = LimitCollectionCreationDeletion,
             AllowAdminAccessToAllCollectionItems = AllowAdminAccessToAllCollectionItems,
             Status = Status

--- a/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Provider/ProviderUserOrganizationDetails.cs
@@ -40,6 +40,8 @@ public class ProviderUserOrganizationDetails
     [JsonConverter(typeof(HtmlEncodingStringConverter))]
     public string ProviderName { get; set; }
     public PlanType PlanType { get; set; }
+    public bool LimitCollectionCreation { get; set; }
+    public bool LimitCollectionDeletion { get; set; }
     public bool LimitCollectionCreationDeletion { get; set; }
     public bool AllowAdminAccessToAllCollectionItems { get; set; }
 }

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -705,9 +705,15 @@ public class OrganizationService : IOrganizationService
             UseSecretsManager = license.UseSecretsManager,
             SmSeats = license.SmSeats,
             SmServiceAccounts = license.SmServiceAccounts,
-            LimitCollectionCreationDeletion = license.LimitCollectionCreationDeletion,
-            AllowAdminAccessToAllCollectionItems = license.AllowAdminAccessToAllCollectionItems,
         };
+
+        // These fields are being removed from consideration when processing
+        // licenses.
+        if (!_featureService.IsEnabled(FeatureFlagKeys.LimitCollectionCreationDeletionSplit))
+        {
+            organization.LimitCollectionCreationDeletion = license.LimitCollectionCreationDeletion;
+            organization.AllowAdminAccessToAllCollectionItems = license.AllowAdminAccessToAllCollectionItems;
+        }
 
         var result = await SignUpAsync(organization, owner.Id, ownerKey, collectionName, false);
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -146,6 +146,7 @@ public static class FeatureFlagKeys
     public const string RemoveServerVersionHeader = "remove-server-version-header";
     public const string AccessIntelligence = "pm-13227-access-intelligence";
     public const string VerifiedSsoDomainEndpoint = "pm-12337-refactor-sso-details-endpoint";
+    public const string LimitCollectionCreationDeletionSplit = "pm-10863-limit-collection-creation-deletion-split";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -164,6 +164,7 @@ public static class FeatureFlagKeys
             { DuoRedirect, "true" },
             { BulkDeviceApproval, "true" },
             { CipherKeyEncryption, "true" },
+            { LimitCollectionCreationDeletionSplit, "true" },
         };
     }
 }

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -53,8 +53,11 @@ public class OrganizationLicense : ILicense
         UseSecretsManager = org.UseSecretsManager;
         SmSeats = org.SmSeats;
         SmServiceAccounts = org.SmServiceAccounts;
+
+        // Deprecated. Left for backwards compatibility with old license versions.
         LimitCollectionCreationDeletion = org.LimitCollectionCreationDeletion;
         AllowAdminAccessToAllCollectionItems = org.AllowAdminAccessToAllCollectionItems;
+        //
 
         if (subscriptionInfo?.Subscription == null)
         {
@@ -138,8 +141,12 @@ public class OrganizationLicense : ILicense
     public bool UseSecretsManager { get; set; }
     public int? SmSeats { get; set; }
     public int? SmServiceAccounts { get; set; }
+
+    // Deprecated. Left for backwards compatibility with old license versions.
     public bool LimitCollectionCreationDeletion { get; set; } = true;
     public bool AllowAdminAccessToAllCollectionItems { get; set; } = true;
+    //
+
     public bool Trial { get; set; }
     public LicenseType? LicenseType { get; set; }
     public string Hash { get; set; }
@@ -150,7 +157,14 @@ public class OrganizationLicense : ILicense
     /// Represents the current version of the license format. Should be updated whenever new fields are added.
     /// </summary>
     /// <remarks>Intentionally set one version behind to allow self hosted users some time to update before
-    /// getting out of date license errors</remarks>
+    /// getting out of date license errors
+    /// </remarks>
+    /// <remarks>
+    /// ⚠ This is important! We are on this license version because of new
+    /// properties that were added for versions 14 and 15. These properties
+    /// were later removed! When you increment to version 16 please delete
+    /// this comment.
+    /// </remarks>
     public const int CurrentLicenseFileVersion = 14;
     private bool ValidLicenseVersion
     {
@@ -366,12 +380,6 @@ public class OrganizationLicense : ILicense
                         organization.SmSeats == SmSeats &&
                         organization.SmServiceAccounts == SmServiceAccounts;
             }
-
-            /*
-             * Version 14 added LimitCollectionCreationDeletion and Version 15 added AllowAdminAccessToAllCollectionItems,
-             * however these are just user settings and it is not worth failing validation if they mismatch.
-             * They are intentionally excluded.
-             */
 
             return valid;
         }

--- a/src/Core/Models/Business/OrganizationLicense.cs
+++ b/src/Core/Models/Business/OrganizationLicense.cs
@@ -381,6 +381,13 @@ public class OrganizationLicense : ILicense
                         organization.SmServiceAccounts == SmServiceAccounts;
             }
 
+            /*
+            * Version 14 added LimitCollectionCreationDeletion and Version
+            * 15 added AllowAdminAccessToAllCollectionItems, however they
+            * are no longer used and are intentionally excluded from
+            * validation.
+            */
+
             return valid;
         }
 

--- a/src/Core/OrganizationFeatures/OrganizationLicenses/UpdateOrganizationLicenseCommand.cs
+++ b/src/Core/OrganizationFeatures/OrganizationLicenses/UpdateOrganizationLicenseCommand.cs
@@ -17,15 +17,18 @@ public class UpdateOrganizationLicenseCommand : IUpdateOrganizationLicenseComman
     private readonly ILicensingService _licensingService;
     private readonly IGlobalSettings _globalSettings;
     private readonly IOrganizationService _organizationService;
+    private readonly IFeatureService _featureService;
 
     public UpdateOrganizationLicenseCommand(
         ILicensingService licensingService,
         IGlobalSettings globalSettings,
-        IOrganizationService organizationService)
+        IOrganizationService organizationService,
+        IFeatureService featureService)
     {
         _licensingService = licensingService;
         _globalSettings = globalSettings;
         _organizationService = organizationService;
+        _featureService = featureService;
     }
 
     public async Task UpdateLicenseAsync(SelfHostedOrganizationDetails selfHostedOrganization,
@@ -59,7 +62,8 @@ public class UpdateOrganizationLicenseCommand : IUpdateOrganizationLicenseComman
     private async Task UpdateOrganizationAsync(SelfHostedOrganizationDetails selfHostedOrganizationDetails, OrganizationLicense license)
     {
         var organization = selfHostedOrganizationDetails.ToOrganization();
-        organization.UpdateFromLicense(license);
+
+        organization.UpdateFromLicense(license, _featureService);
 
         await _organizationService.ReplaceAndUpdateCacheAsync(organization);
     }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Models/Organization.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Models/Organization.cs
@@ -38,9 +38,6 @@ public class OrganizationMapperProfile : Profile
             .ForMember(org => org.ApiKeys, opt => opt.Ignore())
             .ForMember(org => org.Connections, opt => opt.Ignore())
             .ForMember(org => org.Domains, opt => opt.Ignore())
-            // Shadow properties - to be introduced by https://bitwarden.atlassian.net/browse/PM-10863
-            .ForMember(org => org.LimitCollectionCreation, opt => opt.Ignore())
-            .ForMember(org => org.LimitCollectionDeletion, opt => opt.Ignore())
             .ReverseMap();
 
         CreateProjection<Organization, SelfHostedOrganizationDetails>()

--- a/src/Infrastructure.EntityFramework/AdminConsole/Models/Organization.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Models/Organization.cs
@@ -9,10 +9,6 @@ namespace Bit.Infrastructure.EntityFramework.AdminConsole.Models;
 
 public class Organization : Core.AdminConsole.Entities.Organization
 {
-    // Shadow properties - to be introduced by https://bitwarden.atlassian.net/browse/PM-10863
-    public bool LimitCollectionCreation { get => LimitCollectionCreationDeletion; set => LimitCollectionCreationDeletion = value; }
-    public bool LimitCollectionDeletion { get => LimitCollectionCreationDeletion; set => LimitCollectionCreationDeletion = value; }
-
     public virtual ICollection<Cipher> Ciphers { get; set; }
     public virtual ICollection<OrganizationUser> OrganizationUsers { get; set; }
     public virtual ICollection<Group> Groups { get; set; }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationRepository.cs
@@ -99,6 +99,9 @@ public class OrganizationRepository : Repository<Core.AdminConsole.Entities.Orga
                 UseScim = e.UseScim,
                 UseCustomPermissions = e.UseCustomPermissions,
                 UsePolicies = e.UsePolicies,
+                LimitCollectionCreation = e.LimitCollectionCreation,
+                LimitCollectionDeletion = e.LimitCollectionDeletion,
+                // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
                 LimitCollectionCreationDeletion = e.LimitCollectionCreationDeletion,
                 AllowAdminAccessToAllCollectionItems = e.AllowAdminAccessToAllCollectionItems
             }).ToListAsync();

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/OrganizationUserOrganizationDetailsViewQuery.cs
@@ -66,6 +66,9 @@ public class OrganizationUserOrganizationDetailsViewQuery : IQuery<OrganizationU
                         UsePasswordManager = o.UsePasswordManager,
                         SmSeats = o.SmSeats,
                         SmServiceAccounts = o.SmServiceAccounts,
+                        LimitCollectionCreation = o.LimitCollectionCreation,
+                        LimitCollectionDeletion = o.LimitCollectionDeletion,
+                        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
                         LimitCollectionCreationDeletion = o.LimitCollectionCreationDeletion,
                         AllowAdminAccessToAllCollectionItems = o.AllowAdminAccessToAllCollectionItems,
                     };

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/ProviderUserOrganizationDetailsViewQuery.cs
@@ -44,6 +44,9 @@ public class ProviderUserOrganizationDetailsViewQuery : IQuery<ProviderUserOrgan
             ProviderId = x.p.Id,
             ProviderName = x.p.Name,
             PlanType = x.o.PlanType,
+            LimitCollectionCreation = x.o.LimitCollectionCreation,
+            LimitCollectionDeletion = x.o.LimitCollectionDeletion,
+            // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
             LimitCollectionCreationDeletion = x.o.LimitCollectionCreationDeletion,
             AllowAdminAccessToAllCollectionItems = x.o.AllowAdminAccessToAllCollectionItems,
         });

--- a/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
+++ b/test/Api.Test/Vault/AuthorizationHandlers/BulkCollectionAuthorizationHandlerTests.cs
@@ -32,7 +32,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = userType;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Create },
@@ -48,7 +48,7 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanCreateAsync_WhenUser_WithLimitCollectionCreationDeletionFalse_Success(
+    public async Task CanCreateAsync_WhenUser_WithLimitCollectionCreationFalse_Success(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<Collection> collections,
         CurrentContextOrganization organization)
@@ -57,7 +57,7 @@ public class BulkCollectionAuthorizationHandlerTests
 
         organization.Type = OrganizationUserType.User;
 
-        ArrangeOrganizationAbility(sutProvider, organization, false);
+        ArrangeOrganizationAbility(sutProvider, organization, false, false);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Create },
@@ -92,7 +92,7 @@ public class BulkCollectionAuthorizationHandlerTests
             ManageUsers = false
         };
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Create },
@@ -116,7 +116,7 @@ public class BulkCollectionAuthorizationHandlerTests
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider)
     {
         collections.ForEach(c => c.OrganizationId = organization.Id);
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Create },
@@ -904,7 +904,7 @@ public class BulkCollectionAuthorizationHandlerTests
             DeleteAnyCollection = true
         };
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Delete },
@@ -931,7 +931,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = userType;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Delete },
@@ -947,7 +947,7 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanDeleteAsync_WhenUser_LimitCollectionCreationDeletionFalse_WithCanManagePermission_Success(
+    public async Task CanDeleteAsync_WhenUser_LimitCollectionDeletionFalse_WithCanManagePermission_Success(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
         CurrentContextOrganization organization)
@@ -957,7 +957,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = OrganizationUserType.User;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, false);
+        ArrangeOrganizationAbility(sutProvider, organization, false, false);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -982,7 +982,7 @@ public class BulkCollectionAuthorizationHandlerTests
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]
     [BitAutoData(OrganizationUserType.User)]
-    public async Task CanDeleteAsync_LimitCollectionCreationDeletionFalse_AllowAdminAccessToAllCollectionItemsFalse_WithCanManagePermission_Success(
+    public async Task CanDeleteAsync_LimitCollectionDeletionFalse_AllowAdminAccessToAllCollectionItemsFalse_WithCanManagePermission_Success(
         OrganizationUserType userType,
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
@@ -993,7 +993,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = userType;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, false, false);
+        ArrangeOrganizationAbility(sutProvider, organization, false, false, false);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -1017,7 +1017,7 @@ public class BulkCollectionAuthorizationHandlerTests
     [Theory, CollectionCustomization]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]
-    public async Task CanDeleteAsync_WhenAdminOrOwner_LimitCollectionCreationDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_WithCanManagePermission_Success(
+    public async Task CanDeleteAsync_WhenAdminOrOwner_LimitCollectionDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_WithCanManagePermission_Success(
         OrganizationUserType userType,
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
@@ -1028,7 +1028,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = userType;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true, false);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true, false);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -1052,7 +1052,7 @@ public class BulkCollectionAuthorizationHandlerTests
     [Theory, CollectionCustomization]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]
-    public async Task CanDeleteAsync_WhenAdminOrOwner_LimitCollectionCreationDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_WithoutCanManagePermission_Failure(
+    public async Task CanDeleteAsync_WhenAdminOrOwner_LimitCollectionDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_WithoutCanManagePermission_Failure(
         OrganizationUserType userType,
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
@@ -1063,7 +1063,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = userType;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true, false);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true, false);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -1086,7 +1086,7 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanDeleteAsync_WhenUser_LimitCollectionCreationDeletionTrue_AllowAdminAccessToAllCollectionItemsTrue_Failure(
+    public async Task CanDeleteAsync_WhenUser_LimitCollectionDeletionTrue_AllowAdminAccessToAllCollectionItemsTrue_Failure(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
         CurrentContextOrganization organization)
@@ -1096,7 +1096,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = OrganizationUserType.User;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -1119,7 +1119,7 @@ public class BulkCollectionAuthorizationHandlerTests
     }
 
     [Theory, BitAutoData, CollectionCustomization]
-    public async Task CanDeleteAsync_WhenUser_LimitCollectionCreationDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_Failure(
+    public async Task CanDeleteAsync_WhenUser_LimitCollectionDeletionTrue_AllowAdminAccessToAllCollectionItemsFalse_Failure(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
         ICollection<CollectionDetails> collections,
         CurrentContextOrganization organization)
@@ -1129,7 +1129,7 @@ public class BulkCollectionAuthorizationHandlerTests
         organization.Type = OrganizationUserType.User;
         organization.Permissions = new Permissions();
 
-        ArrangeOrganizationAbility(sutProvider, organization, true, false);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true, false);
 
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(actingUserId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
@@ -1171,7 +1171,7 @@ public class BulkCollectionAuthorizationHandlerTests
             ManageUsers = false
         };
 
-        ArrangeOrganizationAbility(sutProvider, organization, true);
+        ArrangeOrganizationAbility(sutProvider, organization, true, true);
 
         var context = new AuthorizationHandlerContext(
             new[] { BulkCollectionOperations.Delete },
@@ -1262,6 +1262,8 @@ public class BulkCollectionAuthorizationHandlerTests
             { collections.First().OrganizationId,
                 new OrganizationAbility
                 {
+                    LimitCollectionCreation = true,
+                    LimitCollectionDeletion = true,
                     LimitCollectionCreationDeletion = true,
                     AllowAdminAccessToAllCollectionItems = true
                 }
@@ -1338,13 +1340,19 @@ public class BulkCollectionAuthorizationHandlerTests
 
     private static void ArrangeOrganizationAbility(
         SutProvider<BulkCollectionAuthorizationHandler> sutProvider,
-        CurrentContextOrganization organization, bool limitCollectionCreationDeletion,
+        CurrentContextOrganization organization,
+        bool limitCollectionCreation,
+        bool limitCollectionDeletion,
         bool allowAdminAccessToAllCollectionItems = true)
     {
         var organizationAbility = new OrganizationAbility();
         organizationAbility.Id = organization.Id;
-        organizationAbility.LimitCollectionCreationDeletion = limitCollectionCreationDeletion;
+        organizationAbility.LimitCollectionCreation = limitCollectionCreation;
+        organizationAbility.LimitCollectionDeletion = limitCollectionDeletion;
+        // Deprecated: remove with https://bitwarden.atlassian.net/browse/PM-10863
+        organizationAbility.LimitCollectionCreationDeletion = limitCollectionCreation || limitCollectionDeletion;
         organizationAbility.AllowAdminAccessToAllCollectionItems = allowAdminAccessToAllCollectionItems;
+
 
         sutProvider.GetDependency<IApplicationCacheService>().GetOrganizationAbilityAsync(organizationAbility.Id)
             .Returns(organizationAbility);

--- a/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
+++ b/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
@@ -111,5 +111,7 @@ public static class OrganizationLicenseFileFixtures
             SmServiceAccounts = 8,
             MaxAutoscaleSmSeats = 101,
             MaxAutoscaleSmServiceAccounts = 102,
+            LimitCollectionCreationDeletion = true,
+            AllowAdminAccessToAllCollectionItems = true,
         };
 }

--- a/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
+++ b/test/Core.Test/Models/Business/OrganizationLicenseFileFixtures.cs
@@ -111,7 +111,5 @@ public static class OrganizationLicenseFileFixtures
             SmServiceAccounts = 8,
             MaxAutoscaleSmSeats = 101,
             MaxAutoscaleSmServiceAccounts = 102,
-            LimitCollectionCreationDeletion = true,
-            AllowAdminAccessToAllCollectionItems = true,
         };
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
@@ -255,6 +255,8 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(organization.SmServiceAccounts, result.SmServiceAccounts);
         Assert.Equal(organization.LimitCollectionCreation, result.LimitCollectionCreation);
         Assert.Equal(organization.LimitCollectionDeletion, result.LimitCollectionDeletion);
+        // Deprecated: https://bitwarden.atlassian.net/browse/PM-10863
+        Assert.Equal(organization.LimitCollectionCreationDeletion, result.LimitCollectionCreationDeletion);
         Assert.Equal(organization.AllowAdminAccessToAllCollectionItems, result.AllowAdminAccessToAllCollectionItems);
     }
 

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepositoryTests.cs
@@ -253,7 +253,8 @@ public class OrganizationUserRepositoryTests
         Assert.Equal(orgUser1.Permissions, result.Permissions);
         Assert.Equal(organization.SmSeats, result.SmSeats);
         Assert.Equal(organization.SmServiceAccounts, result.SmServiceAccounts);
-        Assert.Equal(organization.LimitCollectionCreationDeletion, result.LimitCollectionCreationDeletion);
+        Assert.Equal(organization.LimitCollectionCreation, result.LimitCollectionCreation);
+        Assert.Equal(organization.LimitCollectionDeletion, result.LimitCollectionDeletion);
         Assert.Equal(organization.AllowAdminAccessToAllCollectionItems, result.AllowAdminAccessToAllCollectionItems);
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

### 🧵 Jira Ticket: [PM-10863](https://bitwarden.atlassian.net/browse/PM-10863)

### 📚 Stacked PRs

1. `server`: https://github.com/bitwarden/server/pull/4709
1. `server`: https://github.com/bitwarden/server/pull/4730
1. `clients`: https://github.com/bitwarden/clients/pull/11223
1. `server`: https://github.com/bitwarden/server/pull/4808
    ⬆️ __YOU ARE HERE__
1. `server`: https://github.com/bitwarden/server/pull/4809
1. `clients`: https://github.com/bitwarden/clients/pull/11258
1. `server`: https://github.com/bitwarden/server/pull/4810

## 📔 Objective

### 🤳 The Bigger Picture 

There is an option in the Admin Console that removes collection creation and
deletion controls from all organization members that are not in the Owner and
Admin roles. This PR stack splits this conjoined option into two separate
controls: one to block `create` operations and one to block `delete`
operations. This is a part of an effort to make these settings better align
with what customers expect it to do.

### 👉 This Pull Request 👍

Over the last two PRs we implemented the functional changes requested in this
body of work in `server` and `clients`. This PR is much more simple. It just
enables the feature for self hosted installations by manually setting the
feature flag to `true`.

This PR and the previous two in the stack encompass all of the functional
changes to the system in this PR stack. By now all requested functionality
should be deployed and available to customers. The next three pull requests
are maintenance tasks to support evolutionary database design and feature
toggling.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[PM-10863]: https://bitwarden.atlassian.net/browse/PM-10863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

## Greptile Summary

This pull request enables the 'LimitCollectionCreationDeletionSplit' feature for self-hosted installations, splitting the combined collection creation and deletion control into separate options.

- Added `LimitCollectionCreation` and `LimitCollectionDeletion` properties to various models and entities, replacing the deprecated `LimitCollectionCreationDeletion`
- Updated `OrganizationService` and `UpdateOrganizationLicenseCommand` to handle the new split controls
- Modified `BulkCollectionAuthorizationHandler` to implement separate logic for creation and deletion permissions
- Updated views, controllers, and repositories to support the new granular collection management controls
- Added and modified unit and integration tests to cover the new feature functionality

<!-- /greptile_comment -->