### PR TITLE
[PM-10996] Remove restrict-provider-access feature flag

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -6,7 +6,6 @@ using Bit.Api.Utilities;
 using Bit.Api.Vault.Models.Request;
 using Bit.Api.Vault.Models.Response;
 using Bit.Core;
-using Bit.Core.AdminConsole.Services;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;

--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -37,11 +37,9 @@ public class CiphersController : Controller
     private readonly ICipherService _cipherService;
     private readonly IUserService _userService;
     private readonly IAttachmentStorageService _attachmentStorageService;
-    private readonly IProviderService _providerService;
     private readonly ICurrentContext _currentContext;
     private readonly ILogger<CiphersController> _logger;
     private readonly GlobalSettings _globalSettings;
-    private readonly IFeatureService _featureService;
     private readonly IOrganizationCiphersQuery _organizationCiphersQuery;
     private readonly IApplicationCacheService _applicationCacheService;
     private readonly ICollectionRepository _collectionRepository;
@@ -52,11 +50,9 @@ public class CiphersController : Controller
         ICipherService cipherService,
         IUserService userService,
         IAttachmentStorageService attachmentStorageService,
-        IProviderService providerService,
         ICurrentContext currentContext,
         ILogger<CiphersController> logger,
         GlobalSettings globalSettings,
-        IFeatureService featureService,
         IOrganizationCiphersQuery organizationCiphersQuery,
         IApplicationCacheService applicationCacheService,
         ICollectionRepository collectionRepository)
@@ -66,11 +62,9 @@ public class CiphersController : Controller
         _cipherService = cipherService;
         _userService = userService;
         _attachmentStorageService = attachmentStorageService;
-        _providerService = providerService;
         _currentContext = currentContext;
         _logger = logger;
         _globalSettings = globalSettings;
-        _featureService = featureService;
         _organizationCiphersQuery = organizationCiphersQuery;
         _applicationCacheService = applicationCacheService;
         _collectionRepository = collectionRepository;
@@ -282,8 +276,7 @@ public class CiphersController : Controller
 
     /// <summary>
     /// Permission helper to determine if the current user can use the "/admin" variants of the cipher endpoints.
-    /// Allowed for custom users with EditAnyCollection, providers, unrestricted owners and admins (allowAdminAccess setting is ON).
-    /// Falls back to original EditAnyCollection permission check for when V1 flag is disabled.
+    /// Allowed for custom users with EditAnyCollection, unrestricted owners and admins (allowAdminAccess setting is ON).
     /// TODO: Move this to its own authorization handler or equivalent service - AC-2062
     /// </summary>
     private async Task<bool> CanEditCipherAsAdminAsync(Guid organizationId, IEnumerable<Guid> cipherIds)
@@ -293,23 +286,7 @@ public class CiphersController : Controller
         // If we're not an "admin", we don't need to check the ciphers
         if (org is not ({ Type: OrganizationUserType.Owner or OrganizationUserType.Admin } or { Permissions.EditAnyCollection: true }))
         {
-            // Are we a provider user? If so, we need to be sure we're not restricted
-            // Once the feature flag is removed, this check can be combined with the above
-            if (await _currentContext.ProviderUserForOrgAsync(organizationId))
-            {
-                // Provider is restricted from editing ciphers, so we're not an "admin"
-                if (_featureService.IsEnabled(FeatureFlagKeys.RestrictProviderAccess))
-                {
-                    return false;
-                }
-
-                // Provider is unrestricted, so we're an "admin", don't return early
-            }
-            else
-            {
-                // Not a provider or admin
-                return false;
-            }
+            return false;
         }
 
         // We know we're an "admin", now check the ciphers explicitly (in case admins are restricted)
@@ -366,12 +343,6 @@ public class CiphersController : Controller
             return true;
         }
 
-        // Provider users can edit all ciphers if RestrictProviderAccess is disabled
-        if (await _currentContext.ProviderUserForOrgAsync(organizationId))
-        {
-            return !_featureService.IsEnabled(FeatureFlagKeys.RestrictProviderAccess);
-        }
-
         return false;
     }
 
@@ -389,12 +360,6 @@ public class CiphersController : Controller
             return true;
         }
 
-        // Provider users can only access organization ciphers if RestrictProviderAccess is disabled
-        if (await _currentContext.ProviderUserForOrgAsync(organizationId))
-        {
-            return !_featureService.IsEnabled(FeatureFlagKeys.RestrictProviderAccess);
-        }
-
         return false;
     }
 
@@ -410,12 +375,6 @@ public class CiphersController : Controller
         { Permissions.EditAnyCollection: true })
         {
             return true;
-        }
-
-        // Provider users can only access all ciphers if RestrictProviderAccess is disabled
-        if (await _currentContext.ProviderUserForOrgAsync(organizationId))
-        {
-            return !_featureService.IsEnabled(FeatureFlagKeys.RestrictProviderAccess);
         }
 
         return false;

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -116,7 +116,6 @@ public static class FeatureFlagKeys
     public const string EmailVerificationDisableTimingDelays = "email-verification-disable-timing-delays";
     public const string AnhFcmv1Migration = "anh-fcmv1-migration";
     public const string ExtensionRefresh = "extension-refresh";
-    public const string RestrictProviderAccess = "restrict-provider-access";
     public const string PM4154BulkEncryptionService = "PM-4154-bulk-encryption-service";
     public const string VaultBulkManagementAction = "vault-bulk-management-action";
     public const string BulkDeviceApproval = "bulk-device-approval";

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Security.Claims;
 using Bit.Api.Vault.Controllers;
 using Bit.Api.Vault.Models.Request;
-using Bit.Core;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -186,18 +186,14 @@ public class CiphersControllerTests
     }
 
     [Theory]
-    [BitAutoData(false)]
-    [BitAutoData(false)]
-    [BitAutoData(true)]
-    public async Task CanEditCiphersAsAdminAsync_Providers(
-        bool restrictProviders, Cipher cipher, CurrentContextOrganization organization, Guid userId, SutProvider<CiphersController> sutProvider
+    [BitAutoData]
+    public async Task CannotEditCiphersAsAdminAsync_Providers(Cipher cipher, CurrentContextOrganization organization, Guid userId, SutProvider<CiphersController> sutProvider
     )
     {
         cipher.OrganizationId = organization.Id;
 
-        // Simulate that the user is a provider for the organization
-        sutProvider.GetDependency<ICurrentContext>().EditAnyCollection(organization.Id).Returns(true);
-        sutProvider.GetDependency<ICurrentContext>().ProviderUserForOrgAsync(organization.Id).Returns(true);
+        // Simulate that the user is a provider for the organization (i.e. not a member, so there is no organization available)
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns((CurrentContextOrganization)null);
 
         sutProvider.GetDependency<IUserService>().GetProperUserId(default).ReturnsForAnyArgs(userId);
 
@@ -209,22 +205,10 @@ public class CiphersControllerTests
             Id = organization.Id,
             AllowAdminAccessToAllCollectionItems = false
         });
-        sutProvider.GetDependency<IFeatureService>().IsEnabled(FeatureFlagKeys.RestrictProviderAccess).Returns(restrictProviders);
 
-        // Non restricted providers should succeed
-        if (!restrictProviders)
-        {
-            await sutProvider.Sut.DeleteAdmin(cipher.Id.ToString());
-            await sutProvider.GetDependency<ICipherService>().ReceivedWithAnyArgs()
-                .DeleteAsync(default, default);
-        }
-        else // Otherwise, they should fail
-        {
-            await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.DeleteAdmin(cipher.Id.ToString()));
-            await sutProvider.GetDependency<ICipherService>().DidNotReceiveWithAnyArgs()
-                .DeleteAsync(default, default);
-        }
-
-        await sutProvider.GetDependency<ICurrentContext>().Received().ProviderUserForOrgAsync(organization.Id);
+        // Providers should not be allowed to edit ciphers as Admin
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.DeleteAdmin(cipher.Id.ToString()));
+        await sutProvider.GetDependency<ICipherService>().DidNotReceiveWithAnyArgs()
+            .DeleteAsync(default, default);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10996 Remove restrict-provider-access feature flag](https://bitwarden.atlassian.net/browse/PM-10996)
[PM-12055](https://bitwarden.atlassian.net/browse/PM-12055)

## 📔 Objective

Remove the restrict-provider-access feature flag and any references. 

> [!IMPORTANT]
> This should only be merged **after** the corresponding [Clients PR](https://github.com/bitwarden/clients/pull/10977) has been fully **released** to all clients.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12055]: https://bitwarden.atlassian.net/browse/PM-12055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

## Greptile Summary

This pull request removes the 'restrict-provider-access' feature flag, simplifying authorization logic for provider users in the CiphersController and updating related tests.

- Removed 'RestrictProviderAccess' constant from `src/Core/Constants.cs`
- Updated `src/Api/Vault/Controllers/CiphersController.cs` to remove feature flag checks
- Modified `test/Api.Test/Vault/Controllers/CiphersControllerTests.cs` to ensure providers cannot edit ciphers as admins
- Enhances security by consistently restricting provider access to admin-level cipher operations

<!-- /greptile_comment -->