### PR TITLE
[AC-2971] Draft: Policy strategy pattern

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyStrategy.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/IPolicyStrategy.cs
@@ -1,0 +1,30 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+
+public interface IPolicyStrategy
+{
+    /// <summary>
+    /// The PolicyType that the strategy is responsible for handling.
+    /// </summary>
+    public PolicyType Type { get; }
+
+    /// <summary>
+    /// A method that is called when the policy state changes from disabled to enabled, before
+    /// it is saved to the database.
+    /// For example, this can be used for validation before saving or for side effects.
+    /// </summary>
+    /// <param name="policy">The updated policy object.</param>
+    /// <param name="savingUserId">The current user who is updating the policy.</param>
+    public Task HandleEnable(Policy policy, Guid? savingUserId);
+
+    /// <summary>
+    /// A method that is called when the policy state changes from enabled to disabled, before
+    /// it is saved to the database.
+    /// For example, this can be used for validation before saving or for side effects.
+    /// </summary>
+    /// <param name="policy">The updated policy object.</param>
+    /// <param name="savingUserId">The current user who is updating the policy.</param>
+    public Task HandleDisable(Policy policy, Guid? savingUserId);
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/SingleOrgPolicyStrategy.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/SingleOrgPolicyStrategy.cs
@@ -38,7 +38,7 @@ public class SingleOrgPolicyStrategy : IPolicyStrategy
     {
         // Remove non-compliant users
         var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(policy.OrganizationId);
-        var org = await _organizationRepository.GetByIdAsync(policy.Id);
+        var org = await _organizationRepository.GetByIdAsync(policy.OrganizationId);
         if (org == null)
         {
             throw new NotFoundException("Organization not found.");

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/SingleOrgPolicyStrategy.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/SingleOrgPolicyStrategy.cs
@@ -1,0 +1,99 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Auth.Enums;
+using Bit.Core.Auth.Repositories;
+using Bit.Core.Enums;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Bit.Core.Services;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Implementations;
+
+public class SingleOrgPolicyStrategy : IPolicyStrategy
+{
+    public PolicyType Type => PolicyType.SingleOrg;
+
+    private readonly IOrganizationUserRepository _organizationUserRepository;
+    private readonly IMailService _mailService;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IPolicyRepository _policyRepository;
+    private readonly ISsoConfigRepository _ssoConfigRepository;
+
+    public SingleOrgPolicyStrategy(
+        IOrganizationUserRepository organizationUserRepository,
+        IMailService mailService,
+        IOrganizationRepository organizationRepository,
+        IPolicyRepository policyRepository,
+        ISsoConfigRepository ssoConfigRepository)
+    {
+        _organizationUserRepository = organizationUserRepository;
+        _mailService = mailService;
+        _organizationRepository = organizationRepository;
+        _policyRepository = policyRepository;
+        _ssoConfigRepository = ssoConfigRepository;
+    }
+
+    public async Task HandleEnable(Policy policy, Guid? savingUserId)
+    {
+        // Remove non-compliant users
+        var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(policy.OrganizationId);
+        var org = await _organizationRepository.GetByIdAsync(policy.Id);
+        if (org == null)
+        {
+            throw new NotFoundException("Organization not found.");
+        }
+
+        var removableOrgUsers = orgUsers.Where(ou =>
+            ou.Status != OrganizationUserStatusType.Invited &&
+            ou.Status != OrganizationUserStatusType.Revoked &&
+            ou.Type != OrganizationUserType.Owner &&
+            ou.Type != OrganizationUserType.Admin &&
+            ou.UserId != savingUserId
+            ).ToList();
+
+        var userOrgs = await _organizationUserRepository.GetManyByManyUsersAsync(
+                removableOrgUsers.Select(ou => ou.UserId!.Value));
+        foreach (var orgUser in removableOrgUsers)
+        {
+            if (userOrgs.Any(ou => ou.UserId == orgUser.UserId
+                        && ou.OrganizationId != org.Id
+                        && ou.Status != OrganizationUserStatusType.Invited))
+            {
+                // TODO: OrganizationService causes a circular dependency here, we either pass it into all handlers
+                // TODO: like we do with PolicyService at the moment, or we investigate and break that circle
+                // await _organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
+                //     savingUserId);
+                await _mailService.SendOrganizationUserRemovedForPolicySingleOrgEmailAsync(
+                    org.DisplayName(), orgUser.Email);
+            }
+        }
+    }
+
+    public async Task HandleDisable(Policy policy, Guid? savingUserId)
+    {
+        // Do not allow this policy to be disabled if a dependent policy is still enabled
+        var policies = await _policyRepository.GetManyByOrganizationIdAsync(policy.OrganizationId);
+        if (policies.Any(p => p.Type == PolicyType.RequireSso && p.Enabled))
+        {
+            throw new BadRequestException("Single Sign-On Authentication policy is enabled.");
+        }
+
+        if (policies.Any(p => p.Type == PolicyType.MaximumVaultTimeout && p.Enabled))
+        {
+            throw new BadRequestException("Maximum Vault Timeout policy is enabled.");
+        }
+
+        if (policies.Any(p => p.Type == PolicyType.ResetPassword && p.Enabled))
+        {
+            throw new BadRequestException("Account Recovery policy is enabled.");
+        }
+
+        // Do not allow this policy to be disabled if Key Connector is being used
+        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(policy.OrganizationId);
+        if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.KeyConnector)
+        {
+            throw new BadRequestException("Key Connector is enabled.");
+        }
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Implementations;
+using Bit.Core.AdminConsole.Services;
+using Bit.Core.AdminConsole.Services.Implementations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+
+public static class PolicyServiceCollectionExtensions
+{
+    public static void AddPolicyServices(this IServiceCollection services)
+    {
+        services.AddScoped<IPolicyService, PolicyService>();
+        services.AddScoped<IPolicyStrategy, SingleOrgPolicyStrategy>();
+    }
+}

--- a/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/PolicyService.cs
@@ -1,10 +1,8 @@
 ﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.Repositories;
-using Bit.Core.Auth.Enums;
-using Bit.Core.Auth.Repositories;
-using Bit.Core.Auth.UserFeatures.TwoFactorAuth.Interfaces;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -22,11 +20,8 @@ public class PolicyService : IPolicyService
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IPolicyRepository _policyRepository;
-    private readonly ISsoConfigRepository _ssoConfigRepository;
-    private readonly IMailService _mailService;
     private readonly GlobalSettings _globalSettings;
-    private readonly IFeatureService _featureService;
-    private readonly ITwoFactorIsEnabledQuery _twoFactorIsEnabledQuery;
+    private readonly IEnumerable<IPolicyStrategy> _policyStrategies;
 
     public PolicyService(
         IApplicationCacheService applicationCacheService,
@@ -34,27 +29,22 @@ public class PolicyService : IPolicyService
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
         IPolicyRepository policyRepository,
-        ISsoConfigRepository ssoConfigRepository,
-        IMailService mailService,
         GlobalSettings globalSettings,
-        IFeatureService featureService,
-        ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery)
+        IEnumerable<IPolicyStrategy> policyStrategies)
     {
         _applicationCacheService = applicationCacheService;
         _eventService = eventService;
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;
         _policyRepository = policyRepository;
-        _ssoConfigRepository = ssoConfigRepository;
-        _mailService = mailService;
         _globalSettings = globalSettings;
-        _featureService = featureService;
-        _twoFactorIsEnabledQuery = twoFactorIsEnabledQuery;
+        _policyStrategies = policyStrategies;
     }
 
     public async Task SaveAsync(Policy policy, IUserService userService, IOrganizationService organizationService,
         Guid? savingUserId)
     {
+        // TODO: this could use the cache
         var org = await _organizationRepository.GetByIdAsync(policy.OrganizationId);
         if (org == null)
         {
@@ -66,36 +56,33 @@ public class PolicyService : IPolicyService
             throw new BadRequestException("This organization cannot use policies.");
         }
 
-        // FIXME: This method will throw a bunch of errors based on if the
-        // policy that is being applied requires some other policy that is
-        // not enabled. It may be advisable to refactor this into a domain
-        // object and get this kind of stuff out of the service.
-        await HandleDependentPoliciesAsync(policy, org);
+        var currentPolicyIsEnabled =
+            policy.Id != default &&
+            (await _policyRepository.GetByIdAsync(policy.Id))?.Enabled == true;
+
+        var policyStrategy = _policyStrategies.Single(strategy => strategy.Type == policy.Type);
+        if (!currentPolicyIsEnabled && policy.Enabled)
+        {
+            await policyStrategy.HandleEnable(policy, savingUserId);
+        }
+        else if (currentPolicyIsEnabled && !policy.Enabled)
+        {
+            await policyStrategy.HandleDisable(policy, savingUserId);
+        }
+
+        // Note: If the policy's Enabled state is not changing, no handler actions are called.
+        // This may need to be changed in the future if a policy has additional requirements.
 
         var now = DateTime.UtcNow;
-        if (policy.Id == default(Guid))
+        if (policy.Id == default)
         {
             policy.CreationDate = now;
         }
 
         policy.RevisionDate = now;
 
-        // We can exit early for disable operations, because they are
-        // simpler.
-        if (!policy.Enabled)
-        {
-            await SetPolicyConfiguration(policy);
-            return;
-        }
-
-        if (_featureService.IsEnabled(FeatureFlagKeys.MembersTwoFAQueryOptimization))
-        {
-            await EnablePolicy_vNext(policy, org, organizationService, savingUserId);
-            return;
-        }
-
-        await EnablePolicy(policy, org, userService, organizationService, savingUserId);
-        return;
+        await _policyRepository.UpsertAsync(policy);
+        await _eventService.LogPolicyEventAsync(policy, EventType.Policy_Updated);
     }
 
     public async Task<MasterPasswordPolicyData> GetMasterPasswordPolicyForUserAsync(User user)
@@ -160,224 +147,5 @@ public class PolicyService : IPolicyService
         }
 
         return new[] { OrganizationUserType.Owner, OrganizationUserType.Admin };
-    }
-
-    private async Task DependsOnSingleOrgAsync(Organization org)
-    {
-        var singleOrg = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.SingleOrg);
-        if (singleOrg?.Enabled != true)
-        {
-            throw new BadRequestException("Single Organization policy not enabled.");
-        }
-    }
-
-    private async Task RequiredBySsoAsync(Organization org)
-    {
-        var requireSso = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.RequireSso);
-        if (requireSso?.Enabled == true)
-        {
-            throw new BadRequestException("Single Sign-On Authentication policy is enabled.");
-        }
-    }
-
-    private async Task RequiredByKeyConnectorAsync(Organization org)
-    {
-        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
-        if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.KeyConnector)
-        {
-            throw new BadRequestException("Key Connector is enabled.");
-        }
-    }
-
-    private async Task RequiredByAccountRecoveryAsync(Organization org)
-    {
-        var requireSso = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.ResetPassword);
-        if (requireSso?.Enabled == true)
-        {
-            throw new BadRequestException("Account recovery policy is enabled.");
-        }
-    }
-
-    private async Task RequiredByVaultTimeoutAsync(Organization org)
-    {
-        var vaultTimeout = await _policyRepository.GetByOrganizationIdTypeAsync(org.Id, PolicyType.MaximumVaultTimeout);
-        if (vaultTimeout?.Enabled == true)
-        {
-            throw new BadRequestException("Maximum Vault Timeout policy is enabled.");
-        }
-    }
-
-    private async Task RequiredBySsoTrustedDeviceEncryptionAsync(Organization org)
-    {
-        var ssoConfig = await _ssoConfigRepository.GetByOrganizationIdAsync(org.Id);
-        if (ssoConfig?.GetData()?.MemberDecryptionType == MemberDecryptionType.TrustedDeviceEncryption)
-        {
-            throw new BadRequestException("Trusted device encryption is on and requires this policy.");
-        }
-    }
-
-    private async Task HandleDependentPoliciesAsync(Policy policy, Organization org)
-    {
-        switch (policy.Type)
-        {
-            case PolicyType.SingleOrg:
-                if (!policy.Enabled)
-                {
-                    await RequiredBySsoAsync(org);
-                    await RequiredByVaultTimeoutAsync(org);
-                    await RequiredByKeyConnectorAsync(org);
-                    await RequiredByAccountRecoveryAsync(org);
-                }
-                break;
-
-            case PolicyType.RequireSso:
-                if (policy.Enabled)
-                {
-                    await DependsOnSingleOrgAsync(org);
-                }
-                else
-                {
-                    await RequiredByKeyConnectorAsync(org);
-                    await RequiredBySsoTrustedDeviceEncryptionAsync(org);
-                }
-                break;
-
-            case PolicyType.ResetPassword:
-                if (!policy.Enabled || policy.GetDataModel<ResetPasswordDataModel>()?.AutoEnrollEnabled == false)
-                {
-                    await RequiredBySsoTrustedDeviceEncryptionAsync(org);
-                }
-
-                if (policy.Enabled)
-                {
-                    await DependsOnSingleOrgAsync(org);
-                }
-                break;
-
-            case PolicyType.MaximumVaultTimeout:
-                if (policy.Enabled)
-                {
-                    await DependsOnSingleOrgAsync(org);
-                }
-                break;
-        }
-    }
-
-    private async Task SetPolicyConfiguration(Policy policy)
-    {
-        await _policyRepository.UpsertAsync(policy);
-        await _eventService.LogPolicyEventAsync(policy, EventType.Policy_Updated);
-    }
-
-    private async Task EnablePolicy(Policy policy, Organization org, IUserService userService, IOrganizationService organizationService, Guid? savingUserId)
-    {
-        var currentPolicy = await _policyRepository.GetByIdAsync(policy.Id);
-        if (!currentPolicy?.Enabled ?? true)
-        {
-            var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(policy.OrganizationId);
-            var removableOrgUsers = orgUsers.Where(ou =>
-                ou.Status != OrganizationUserStatusType.Invited && ou.Status != OrganizationUserStatusType.Revoked &&
-                ou.Type != OrganizationUserType.Owner && ou.Type != OrganizationUserType.Admin &&
-                ou.UserId != savingUserId);
-            switch (policy.Type)
-            {
-                case PolicyType.TwoFactorAuthentication:
-                    // Reorder by HasMasterPassword to prioritize checking users without a master if they have 2FA enabled
-                    foreach (var orgUser in removableOrgUsers.OrderBy(ou => ou.HasMasterPassword))
-                    {
-                        if (!await userService.TwoFactorIsEnabledAsync(orgUser))
-                        {
-                            if (!orgUser.HasMasterPassword)
-                            {
-                                throw new BadRequestException(
-                                    "Policy could not be enabled. Non-compliant members will lose access to their accounts. Identify members without two-step login from the policies column in the members page.");
-                            }
-
-                            await organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
-                                savingUserId);
-                            await _mailService.SendOrganizationUserRemovedForPolicyTwoStepEmailAsync(
-                                org.DisplayName(), orgUser.Email);
-                        }
-                    }
-                    break;
-                case PolicyType.SingleOrg:
-                    var userOrgs = await _organizationUserRepository.GetManyByManyUsersAsync(
-                            removableOrgUsers.Select(ou => ou.UserId.Value));
-                    foreach (var orgUser in removableOrgUsers)
-                    {
-                        if (userOrgs.Any(ou => ou.UserId == orgUser.UserId
-                                    && ou.OrganizationId != org.Id
-                                    && ou.Status != OrganizationUserStatusType.Invited))
-                        {
-                            await organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
-                                savingUserId);
-                            await _mailService.SendOrganizationUserRemovedForPolicySingleOrgEmailAsync(
-                                org.DisplayName(), orgUser.Email);
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        await SetPolicyConfiguration(policy);
-    }
-
-    private async Task EnablePolicy_vNext(Policy policy, Organization org, IOrganizationService organizationService, Guid? savingUserId)
-    {
-        var currentPolicy = await _policyRepository.GetByIdAsync(policy.Id);
-        if (!currentPolicy?.Enabled ?? true)
-        {
-            var orgUsers = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(policy.OrganizationId);
-            var organizationUsersTwoFactorEnabled = await _twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(orgUsers);
-            var removableOrgUsers = orgUsers.Where(ou =>
-                ou.Status != OrganizationUserStatusType.Invited && ou.Status != OrganizationUserStatusType.Revoked &&
-                ou.Type != OrganizationUserType.Owner && ou.Type != OrganizationUserType.Admin &&
-                ou.UserId != savingUserId);
-            switch (policy.Type)
-            {
-                case PolicyType.TwoFactorAuthentication:
-                    // Reorder by HasMasterPassword to prioritize checking users without a master if they have 2FA enabled
-                    foreach (var orgUser in removableOrgUsers.OrderBy(ou => ou.HasMasterPassword))
-                    {
-                        var userTwoFactorEnabled = organizationUsersTwoFactorEnabled.FirstOrDefault(u => u.user.Id == orgUser.Id).twoFactorIsEnabled;
-                        if (!userTwoFactorEnabled)
-                        {
-                            if (!orgUser.HasMasterPassword)
-                            {
-                                throw new BadRequestException(
-                                    "Policy could not be enabled. Non-compliant members will lose access to their accounts. Identify members without two-step login from the policies column in the members page.");
-                            }
-
-                            await organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
-                                savingUserId);
-                            await _mailService.SendOrganizationUserRemovedForPolicyTwoStepEmailAsync(
-                                org.DisplayName(), orgUser.Email);
-                        }
-                    }
-                    break;
-                case PolicyType.SingleOrg:
-                    var userOrgs = await _organizationUserRepository.GetManyByManyUsersAsync(
-                            removableOrgUsers.Select(ou => ou.UserId.Value));
-                    foreach (var orgUser in removableOrgUsers)
-                    {
-                        if (userOrgs.Any(ou => ou.UserId == orgUser.UserId
-                                    && ou.OrganizationId != org.Id
-                                    && ou.Status != OrganizationUserStatusType.Invited))
-                        {
-                            await organizationService.DeleteUserAsync(policy.OrganizationId, orgUser.Id,
-                                savingUserId);
-                            await _mailService.SendOrganizationUserRemovedForPolicySingleOrgEmailAsync(
-                                org.DisplayName(), orgUser.Email);
-                        }
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        await SetPolicyConfiguration(policy);
     }
 }

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using AspNetCoreRateLimit;
 using Bit.Core.AdminConsole.Models.Business.Tokenables;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.AdminConsole.Services.Implementations;
 using Bit.Core.AdminConsole.Services.NoopImplementations;
@@ -102,9 +103,9 @@ public static class ServiceCollectionExtensions
         services.AddUserServices(globalSettings);
         services.AddTrialInitiationServices();
         services.AddOrganizationServices(globalSettings);
+        services.AddPolicyServices();
         services.AddScoped<ICollectionService, CollectionService>();
         services.AddScoped<IGroupService, GroupService>();
-        services.AddScoped<IPolicyService, PolicyService>();
         services.AddScoped<IEventService, EventService>();
         services.AddScoped<IEmergencyAccessService, EmergencyAccessService>();
         services.AddSingleton<IDeviceService, DeviceService>();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
TBA

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This is a proof of concept for refactoring the server-side PolicyService.

`PolicyService.SaveAsync` takes up most of the class, and it has the following problems:
* Lots of conditional logic and generally a bit hard to follow
* Bloated, increases in size as we add more policy types
* Because all policies use the same class, high risk of regression when changing any one policy
* Requires a high degree of knowledge about all policies, generally has too many responsibilities

This PR suggests implementing a [strategy pattern](https://refactoring.guru/design-patterns/strategy) to handle enabling and disabling policies. Each `PolicyType` should have a corresponding `IPolicyStrategy` implementation, which can be used to handle actions when the policy is changed from enabled -> disabled or vice versa. `PolicyService` then injects all strategies and simply delegates the work to the matching strategy.

This also allows for easier unit testing, which can be done for each strategy, rather than the entire PolicyService class.

This PR shows how this could work, using the Single Org policy as an example. Please provide feedback to help us plan future tech debt work.

**Future improvements - but out of scope for now**

These strategies could also be used for other policy-specific logic, such as:
* [reconciling multiple policies](https://github.com/bitwarden/server/blob/f21d43f252920190e31e36a0f98f308d59230fdf/src/Core/AdminConsole/Services/Implementations/PolicyService.cs#L88-L89)
* [determining which users are exempt from the policy](https://github.com/bitwarden/server/blob/f21d43f252920190e31e36a0f98f308d59230fdf/src/Core/AdminConsole/Services/Implementations/PolicyService.cs#L134-L135)

Separating strategies from the service could also let us have different code ownership, e.g. teams own policies that affect their own domains (something we've talked about for a while now).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request implements a strategy pattern for policy management in the PolicyService, aiming to improve modularity and reduce complexity.

- Introduced `IPolicyStrategy` interface and `SingleOrgPolicyStrategy` implementation for handling Single Organization policy
- Refactored `PolicyService.SaveAsync` to delegate policy handling to appropriate strategies
- Added `PolicyServiceCollectionExtensions` for registering policy-related services
- Modified `SharedWeb/Utilities/ServiceCollectionExtensions.cs` to include `AddPolicyServices()` method
- Simplified `PolicyService` by removing conditional logic and reducing dependencies

<!-- /greptile_comment -->