### PR TITLE
[PM-11406] Account Management: Prevent a verified user from deleting their account

### DIFF
--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -584,7 +584,7 @@ public class AccountsController : Controller
             if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning)
                 && await _userService.IsManagedByAnyOrganizationAsync(user.Id))
             {
-                throw new BadRequestException("Accounts managed by an organization cannot be deleted.");
+                throw new BadRequestException("Cannot delete accounts owned by an organization. Contact your organization administrator for additional details.");
             }
 
             var result = await _userService.DeleteAsync(user);

--- a/src/Api/Auth/Controllers/AccountsController.cs
+++ b/src/Api/Auth/Controllers/AccountsController.cs
@@ -580,6 +580,13 @@ public class AccountsController : Controller
         }
         else
         {
+            // If Account Deprovisioning is enabled, we need to check if the user is managed by any organization.
+            if (_featureService.IsEnabled(FeatureFlagKeys.AccountDeprovisioning)
+                && await _userService.IsManagedByAnyOrganizationAsync(user.Id))
+            {
+                throw new BadRequestException("Accounts managed by an organization cannot be deleted.");
+            }
+
             var result = await _userService.DeleteAsync(user);
             if (result.Succeeded)
             {

--- a/src/Core/Auth/Models/Mail/CannotDeleteManagedAccountViewModel.cs
+++ b/src/Core/Auth/Models/Mail/CannotDeleteManagedAccountViewModel.cs
@@ -1,0 +1,7 @@
+﻿using Bit.Core.Models.Mail;
+
+namespace Bit.Core.Auth.Models.Mail;
+
+public class CannotDeleteManagedAccountViewModel : BaseMailModel
+{
+}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/CannotDeleteManagedAccount.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/CannotDeleteManagedAccount.html.hbs
@@ -1,0 +1,15 @@
+﻿{{#>FullHtmlLayout}}
+<table width="100%" cellpadding="0" cellspacing="0" style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+    <tr style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0 0 10px; -webkit-text-size-adjust: none; text-align: left;" valign="top" align="center">
+            You have requested to delete your account. This action cannot be completed because your account is owned by an organization.
+        </td>
+    </tr>
+    <tr style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
+        <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none; text-align: left;" valign="top" align="center">
+            Please contact your organization administrator for additional details.
+            <br style="margin: 0; box-sizing: border-box; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;" />
+        </td>
+    </tr>
+</table>
+{{/FullHtmlLayout}}

--- a/src/Core/MailTemplates/Handlebars/AdminConsole/CannotDeleteManagedAccount.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/AdminConsole/CannotDeleteManagedAccount.text.hbs
@@ -1,0 +1,6 @@
+﻿{{#>BasicTextLayout}}
+You have requested to delete your account. This action cannot be completed because your account is owned by an organization.
+
+Please contact your organization administrator for additional details.
+
+{{/BasicTextLayout}}

--- a/src/Core/Services/IMailService.cs
+++ b/src/Core/Services/IMailService.cs
@@ -18,6 +18,7 @@ public interface IMailService
         ProductTierType productTier,
         IEnumerable<ProductType> products);
     Task SendVerifyDeleteEmailAsync(string email, Guid userId, string token);
+    Task SendCannotDeleteManagedAccountEmailAsync(string email);
     Task SendChangeEmailAlreadyExistsEmailAsync(string fromEmail, string toEmail);
     Task SendChangeEmailEmailAsync(string newEmailAddress, string token);
     Task SendTwoFactorEmailAsync(string email, string token);

--- a/src/Core/Services/Implementations/HandlebarsMailService.cs
+++ b/src/Core/Services/Implementations/HandlebarsMailService.cs
@@ -112,6 +112,19 @@ public class HandlebarsMailService : IMailService
         await _mailDeliveryService.SendEmailAsync(message);
     }
 
+    public async Task SendCannotDeleteManagedAccountEmailAsync(string email)
+    {
+        var message = CreateDefaultMessage("Delete Your Account", email);
+        var model = new CannotDeleteManagedAccountViewModel
+        {
+            WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+            SiteName = _globalSettings.SiteName,
+        };
+        await AddMessageContentAsync(message, "AdminConsole.CannotDeleteManagedAccount", model);
+        message.Category = "CannotDeleteManagedAccount";
+        await _mailDeliveryService.SendEmailAsync(message);
+    }
+
     public async Task SendChangeEmailAlreadyExistsEmailAsync(string fromEmail, string toEmail)
     {
         var message = CreateDefaultMessage("Your Email Change", toEmail);

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -293,6 +293,12 @@ public class UserService : UserManager<User>, IUserService, IDisposable
             return;
         }
 
+        if (await IsManagedByAnyOrganizationAsync(user.Id))
+        {
+            await _mailService.SendCannotDeleteManagedAccountEmailAsync(user.Email);
+            return;
+        }
+
         var token = await base.GenerateUserTokenAsync(user, TokenOptions.DefaultProvider, "DeleteAccount");
         await _mailService.SendVerifyDeleteEmailAsync(user.Email, user.Id, token);
     }

--- a/src/Core/Services/NoopImplementations/NoopMailService.cs
+++ b/src/Core/Services/NoopImplementations/NoopMailService.cs
@@ -94,6 +94,11 @@ public class NoopMailService : IMailService
         return Task.FromResult(0);
     }
 
+    public Task SendCannotDeleteManagedAccountEmailAsync(string email)
+    {
+        return Task.FromResult(0);
+    }
+
     public Task SendPasswordlessSignInAsync(string returnUrl, string token, string email)
     {
         return Task.FromResult(0);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11406

## 📔 Objective

> - Block `AccountsController.Delete`
> - Update the email sent by `AccountsController.PostDeleteRecover` to note that the user cannot use the recover-delete flow

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request implements changes to prevent verified users managed by an organization from deleting their accounts and updates the email notification system accordingly.

- Added check in `AccountsController.Delete` to block account deletion for organization-managed users
- Introduced new `CannotDeleteManagedAccountViewModel` and corresponding HTML/text email templates
- Added `SendCannotDeleteManagedAccountEmailAsync` method to `IMailService` and its implementations
- Modified `UserService.SendDeleteConfirmationAsync` to handle managed user scenarios
- Implemented new unit tests in `AccountsControllerTests` to verify deletion prevention logic

<!-- /greptile_comment -->