### PR TITLE
[PM-10394] Add new item type ssh key

### DIFF
--- a/src/Api/Vault/Controllers/SyncController.cs
+++ b/src/Api/Vault/Controllers/SyncController.cs
@@ -1,7 +1,9 @@
 ﻿using Bit.Api.Vault.Models.Response;
+using Bit.Core;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -10,6 +12,7 @@ using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Tools.Repositories;
+using Bit.Core.Vault.Models.Data;
 using Bit.Core.Vault.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -30,6 +33,8 @@ public class SyncController : Controller
     private readonly IPolicyRepository _policyRepository;
     private readonly ISendRepository _sendRepository;
     private readonly GlobalSettings _globalSettings;
+    private readonly ICurrentContext _currentContext;
+    private readonly Version _sshKeyCipherMinimumVersion = new(Constants.SSHKeyCipherMinimumVersion);
 
     public SyncController(
         IUserService userService,
@@ -41,7 +46,8 @@ public class SyncController : Controller
         IProviderUserRepository providerUserRepository,
         IPolicyRepository policyRepository,
         ISendRepository sendRepository,
-        GlobalSettings globalSettings)
+        GlobalSettings globalSettings,
+        ICurrentContext currentContext)
     {
         _userService = userService;
         _folderRepository = folderRepository;
@@ -53,6 +59,7 @@ public class SyncController : Controller
         _policyRepository = policyRepository;
         _sendRepository = sendRepository;
         _globalSettings = globalSettings;
+        _currentContext = currentContext;
     }
 
     [HttpGet("")]
@@ -74,7 +81,8 @@ public class SyncController : Controller
         var hasEnabledOrgs = organizationUserDetails.Any(o => o.Enabled);
 
         var folders = await _folderRepository.GetManyByUserIdAsync(user.Id);
-        var ciphers = await _cipherRepository.GetManyByUserIdAsync(user.Id, withOrganizations: hasEnabledOrgs);
+        var allCiphers = await _cipherRepository.GetManyByUserIdAsync(user.Id, withOrganizations: hasEnabledOrgs);
+        var ciphers = FilterSSHKeys(allCiphers);
         var sends = await _sendRepository.GetManyByUserIdAsync(user.Id);
 
         IEnumerable<CollectionDetails> collections = null;
@@ -94,5 +102,17 @@ public class SyncController : Controller
             providerUserDetails, providerUserOrganizationDetails, folders, collections, ciphers,
             collectionCiphersGroupDict, excludeDomains, policies, sends);
         return response;
+    }
+
+    private ICollection<CipherDetails> FilterSSHKeys(ICollection<CipherDetails> ciphers)
+    {
+        if (_currentContext.ClientVersion >= _sshKeyCipherMinimumVersion)
+        {
+            return ciphers;
+        }
+        else
+        {
+            return ciphers.Where(c => c.Type != Core.Vault.Enums.CipherType.SSHKey).ToList();
+        }
     }
 }

--- a/src/Api/Vault/Controllers/SyncController.cs
+++ b/src/Api/Vault/Controllers/SyncController.cs
@@ -106,7 +106,7 @@ public class SyncController : Controller
 
     private ICollection<CipherDetails> FilterSSHKeys(ICollection<CipherDetails> ciphers)
     {
-        if (_currentContext.ClientVersion >= _sshKeyCipherMinimumVersion)
+        if (_currentContext.ClientVersion >= _sshKeyCipherMinimumVersion && _currentContext.DeviceType != DeviceType.Android && _currentContext.DeviceType != DeviceType.iOS && _currentContext.DeviceType != DeviceType.AndroidAmazon)
         {
             return ciphers;
         }

--- a/src/Api/Vault/Models/CipherSSHKeyModel.cs
+++ b/src/Api/Vault/Models/CipherSSHKeyModel.cs
@@ -11,7 +11,6 @@ public class CipherSSHKeyModel
     {
         PrivateKey = data.PrivateKey;
         PublicKey = data.PublicKey;
-        KeyAlgorithm = data.KeyAlgorithm;
         KeyFingerprint = data.KeyFingerprint;
     }
 
@@ -21,9 +20,6 @@ public class CipherSSHKeyModel
     [EncryptedString]
     [EncryptedStringLength(5000)]
     public string PublicKey { get; set; }
-    [EncryptedString]
-    [EncryptedStringLength(1000)]
-    public string KeyAlgorithm { get; set; }
     [EncryptedString]
     [EncryptedStringLength(1000)]
     public string KeyFingerprint { get; set; }

--- a/src/Api/Vault/Models/CipherSSHKeyModel.cs
+++ b/src/Api/Vault/Models/CipherSSHKeyModel.cs
@@ -12,6 +12,7 @@ public class CipherSSHKeyModel
         PrivateKey = data.PrivateKey;
         PublicKey = data.PublicKey;
         KeyAlgorithm = data.KeyAlgorithm;
+        KeyFingerprint = data.KeyFingerprint;
     }
 
     [EncryptedString]
@@ -23,4 +24,7 @@ public class CipherSSHKeyModel
     [EncryptedString]
     [EncryptedStringLength(1000)]
     public string KeyAlgorithm { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(1000)]
+    public string KeyFingerprint { get; set; }
 }

--- a/src/Api/Vault/Models/CipherSSHKeyModel.cs
+++ b/src/Api/Vault/Models/CipherSSHKeyModel.cs
@@ -19,7 +19,7 @@ public class CipherSSHKeyModel
     [EncryptedStringLength(5000)]
     public string PrivateKey { get; set; }
     [EncryptedString]
-    [EncryptedStringLength(1000)]
+    [EncryptedStringLength(5000)]
     public string PublicKey { get; set; }
     [EncryptedString]
     [EncryptedStringLength(1000)]

--- a/src/Api/Vault/Models/CipherSSHKeyModel.cs
+++ b/src/Api/Vault/Models/CipherSSHKeyModel.cs
@@ -1,0 +1,26 @@
+﻿using Bit.Core.Utilities;
+using Bit.Core.Vault.Models.Data;
+
+namespace Bit.Api.Vault.Models;
+
+public class CipherSSHKeyModel
+{
+    public CipherSSHKeyModel() { }
+
+    public CipherSSHKeyModel(CipherSSHKeyData data)
+    {
+        PrivateKey = data.PrivateKey;
+        PublicKey = data.PublicKey;
+        KeyAlgorithm = data.KeyAlgorithm;
+    }
+
+    [EncryptedString]
+    [EncryptedStringLength(5000)]
+    public string PrivateKey { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(1000)]
+    public string PublicKey { get; set; }
+    [EncryptedString]
+    [EncryptedStringLength(1000)]
+    public string KeyAlgorithm { get; set; }
+}

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -37,6 +37,7 @@ public class CipherRequestModel
     public CipherCardModel Card { get; set; }
     public CipherIdentityModel Identity { get; set; }
     public CipherSecureNoteModel SecureNote { get; set; }
+    public CipherSSHKeyModel SSHKey { get; set; }
     public DateTime? LastKnownRevisionDate { get; set; } = null;
 
     public CipherDetails ToCipherDetails(Guid userId, bool allowOrgIdSet = true)
@@ -81,6 +82,9 @@ public class CipherRequestModel
                 break;
             case CipherType.SecureNote:
                 existingCipher.Data = JsonSerializer.Serialize(ToCipherSecureNoteData(), JsonHelpers.IgnoreWritingNull);
+                break;
+            case CipherType.SSHKey:
+                existingCipher.Data = JsonSerializer.Serialize(ToCipherSSHKeyData(), JsonHelpers.IgnoreWritingNull);
                 break;
             default:
                 throw new ArgumentException("Unsupported type: " + nameof(Type) + ".");
@@ -228,6 +232,21 @@ public class CipherRequestModel
             PasswordHistory = PasswordHistory?.Select(ph => ph.ToCipherPasswordHistoryData()),
 
             Type = SecureNote.Type,
+        };
+    }
+
+    private CipherSSHKeyData ToCipherSSHKeyData()
+    {
+        return new CipherSSHKeyData
+        {
+            Name = Name,
+            Notes = Notes,
+            Fields = Fields?.Select(f => f.ToCipherFieldData()),
+            PasswordHistory = PasswordHistory?.Select(ph => ph.ToCipherPasswordHistoryData()),
+
+            PrivateKey = SSHKey.PrivateKey,
+            PublicKey = SSHKey.PublicKey,
+            KeyAlgorithm = SSHKey.KeyAlgorithm,
         };
     }
 }

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -246,7 +246,6 @@ public class CipherRequestModel
 
             PrivateKey = SSHKey.PrivateKey,
             PublicKey = SSHKey.PublicKey,
-            KeyAlgorithm = SSHKey.KeyAlgorithm,
             KeyFingerprint = SSHKey.KeyFingerprint,
         };
     }

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -247,6 +247,7 @@ public class CipherRequestModel
             PrivateKey = SSHKey.PrivateKey,
             PublicKey = SSHKey.PublicKey,
             KeyAlgorithm = SSHKey.KeyAlgorithm,
+            KeyFingerprint = SSHKey.KeyFingerprint,
         };
     }
 }

--- a/src/Api/Vault/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherResponseModel.cs
@@ -48,6 +48,12 @@ public class CipherMiniResponseModel : ResponseModel
                 cipherData = identityData;
                 Identity = new CipherIdentityModel(identityData);
                 break;
+            case CipherType.SSHKey:
+                var sshKeyData = JsonSerializer.Deserialize<CipherSSHKeyData>(cipher.Data);
+                Data = sshKeyData;
+                cipherData = sshKeyData;
+                SSHKey = new CipherSSHKeyModel(sshKeyData);
+                break;
             default:
                 throw new ArgumentException("Unsupported " + nameof(Type) + ".");
         }
@@ -76,6 +82,7 @@ public class CipherMiniResponseModel : ResponseModel
     public CipherCardModel Card { get; set; }
     public CipherIdentityModel Identity { get; set; }
     public CipherSecureNoteModel SecureNote { get; set; }
+    public CipherSSHKeyModel SSHKey { get; set; }
     public IEnumerable<CipherFieldModel> Fields { get; set; }
     public IEnumerable<CipherPasswordHistoryModel> PasswordHistory { get; set; }
     public IEnumerable<AttachmentResponseModel> Attachments { get; set; }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -22,6 +22,7 @@ public static class Constants
     public const int OrganizationSelfHostSubscriptionGracePeriodDays = 60;
 
     public const string Fido2KeyCipherMinimumVersion = "2023.10.0";
+    public const string SSHKeyCipherMinimumVersion = "2024.7.0";
 
     /// <summary>
     /// Used by IdentityServer to identify our own provider.

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -132,6 +132,7 @@ public static class FeatureFlagKeys
     public const string AC2828_ProviderPortalMembersPage = "AC-2828_provider-portal-members-page";
     public const string ProviderClientVaultPrivacyBanner = "ac-2833-provider-client-vault-privacy-banner";
     public const string DeviceTrustLogging = "pm-8285-device-trust-logging";
+    public const string SSHKeyItemVaultItem = "ssh-key-vault-item";
 
     public static List<string> GetAllKeys()
     {

--- a/src/Core/Vault/Enums/CipherType.cs
+++ b/src/Core/Vault/Enums/CipherType.cs
@@ -8,4 +8,5 @@ public enum CipherType : byte
     SecureNote = 2,
     Card = 3,
     Identity = 4,
+    SSHKey = 5,
 }

--- a/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
+++ b/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
@@ -6,6 +6,5 @@ public class CipherSSHKeyData : CipherData
 
     public string PrivateKey { get; set; }
     public string PublicKey { get; set; }
-    public string KeyAlgorithm { get; set; }
     public string KeyFingerprint { get; set; }
 }

--- a/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
+++ b/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
@@ -7,4 +7,5 @@ public class CipherSSHKeyData : CipherData
     public string PrivateKey { get; set; }
     public string PublicKey { get; set; }
     public string KeyAlgorithm { get; set; }
+    public string KeyFingerprint { get; set; }
 }

--- a/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
+++ b/src/Core/Vault/Models/Data/CipherSSHKeyData.cs
@@ -1,0 +1,10 @@
+﻿namespace Bit.Core.Vault.Models.Data;
+
+public class CipherSSHKeyData : CipherData
+{
+    public CipherSSHKeyData() { }
+
+    public string PrivateKey { get; set; }
+    public string PublicKey { get; set; }
+    public string KeyAlgorithm { get; set; }
+}


### PR DESCRIPTION
## 🎟️ Tracking

Server: https://github.com/bitwarden/server/pull/4575
Add Item Type: https://github.com/bitwarden/clients/pull/10360
Add SSH Agent: https://github.com/bitwarden/clients/pull/10293
Add Import/Export: https://github.com/bitwarden/clients/pull/10529

Jira: https://bitwarden.atlassian.net/browse/PM-10395

## 📔 Objective

Add server support for the new ssh key cipher type. This is mostly copy paste from the other cipher types, with the one exception that we are filtering out ssh keys for older clients, using SSHKeyCipherMinimumVersion. We will update this once we know which release ssh keys will be in.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


<!-- greptile_comment -->

## Greptile Summary

This pull request introduces support for a new SSH key cipher type in the Bitwarden server, expanding the vault's capabilities to store and manage SSH keys.

- Added `CipherSSHKeyModel` and `CipherSSHKeyData` classes to represent SSH key data with encrypted properties
- Modified `SyncController` to filter SSH keys based on client version and device type
- Updated `CipherRequestModel` and `CipherResponseModel` to handle the new SSH key cipher type
- Added `SSHKey` enum value to `CipherType` and introduced related constants for version control
- Implemented filtering logic to exclude SSH key ciphers for older clients and certain device types

<!-- /greptile_comment -->