### PR TITLE
Include Context information in config response

### DIFF
--- a/src/Api/Controllers/ConfigController.cs
+++ b/src/Api/Controllers/ConfigController.cs
@@ -23,6 +23,6 @@ public class ConfigController : Controller
     [HttpGet("")]
     public ConfigResponseModel GetConfigs()
     {
-        return new ConfigResponseModel(_globalSettings, _featureService.GetAll());
+        return new ConfigResponseModel(_globalSettings, _featureService.GetAll(), _featureService.GetFlagContext());
     }
 }

--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -38,7 +38,7 @@ public class ConfigResponseModel : ResponseModel
             Sso = globalSettings.BaseServiceUri.Sso
         };
         FeatureStates = featureStates;
-        Context = new ContextResponseModel(featureFlagContext);
+        Context = new ContextResponseModel(featureFlagContext.UserId, featureFlagContext.OrganizationIds);
     }
 }
 
@@ -62,9 +62,9 @@ public class ContextResponseModel
 {
     public Guid? UserId { get; set; }
     public Guid[] OrganizationIds { get; set; }
-    public ContextResponseModel(FeatureFlagContext context)
+    public ContextResponseModel(Guid? userId, Guid[] organizationIds)
     {
-        UserId = context.UserId;
-        OrganizationIds = context.OrganizationIds;
+        UserId = userId;
+        OrganizationIds = organizationIds;
     }
 }

--- a/src/Api/Models/Response/ConfigResponseModel.cs
+++ b/src/Api/Models/Response/ConfigResponseModel.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.Models.Api;
+using Bit.Core.Services;
 using Bit.Core.Settings;
 using Bit.Core.Utilities;
 
@@ -11,6 +12,7 @@ public class ConfigResponseModel : ResponseModel
     public ServerConfigResponseModel Server { get; set; }
     public EnvironmentConfigResponseModel Environment { get; set; }
     public IDictionary<string, object> FeatureStates { get; set; }
+    public ContextResponseModel Context { get; set; }
 
     public ConfigResponseModel() : base("config")
     {
@@ -22,7 +24,7 @@ public class ConfigResponseModel : ResponseModel
 
     public ConfigResponseModel(
         IGlobalSettings globalSettings,
-        IDictionary<string, object> featureStates) : base("config")
+        IDictionary<string, object> featureStates, FeatureFlagContext featureFlagContext) : base("config")
     {
         Version = AssemblyHelpers.GetVersion();
         GitHash = AssemblyHelpers.GetGitHash();
@@ -36,6 +38,7 @@ public class ConfigResponseModel : ResponseModel
             Sso = globalSettings.BaseServiceUri.Sso
         };
         FeatureStates = featureStates;
+        Context = new ContextResponseModel(featureFlagContext);
     }
 }
 
@@ -53,4 +56,15 @@ public class EnvironmentConfigResponseModel
     public string Identity { get; set; }
     public string Notifications { get; set; }
     public string Sso { get; set; }
+}
+
+public class ContextResponseModel
+{
+    public Guid? UserId { get; set; }
+    public Guid[] OrganizationIds { get; set; }
+    public ContextResponseModel(FeatureFlagContext context)
+    {
+        UserId = context.UserId;
+        OrganizationIds = context.OrganizationIds;
+    }
 }

--- a/src/Core/Services/IFeatureService.cs
+++ b/src/Core/Services/IFeatureService.cs
@@ -1,5 +1,11 @@
 ﻿namespace Bit.Core.Services;
 
+public struct FeatureFlagContext
+{
+    public Guid? UserId { get; init; }
+    public Guid[] OrganizationIds { get; init; }
+}
+
 public interface IFeatureService
 {
     /// <summary>
@@ -37,4 +43,5 @@ public interface IFeatureService
     /// </summary>
     /// <returns>A dictionary of feature keys and their values.</returns>
     Dictionary<string, object> GetAll();
+    FeatureFlagContext GetFlagContext();
 }

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -96,11 +96,23 @@ public class LaunchDarklyFeatureService : IFeatureService
         return _client.StringVariation(key, BuildContext(), defaultValue);
     }
 
+    public FeatureFlagContext GetFlagContext()
+    {
+        return new FeatureFlagContext()
+        {
+            UserId = _currentContext.UserId,
+            OrganizationIds = _currentContext.Organizations?.Select(o => o.Id).ToArray()
+        };
+    }
+
     public Dictionary<string, object> GetAll()
     {
         var results = new Dictionary<string, object>();
 
         var keys = FeatureFlagKeys.GetAllKeys();
+
+        results.Add("userId", _currentContext.UserId);
+        results.Add("OrgIds", _currentContext.Organizations?.Select(o => o.Id).ToList());
 
         var values = _client.AllFlagsState(BuildContext());
         if (values.Valid)

--- a/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
+++ b/src/Core/Services/Implementations/LaunchDarklyFeatureService.cs
@@ -111,9 +111,6 @@ public class LaunchDarklyFeatureService : IFeatureService
 
         var keys = FeatureFlagKeys.GetAllKeys();
 
-        results.Add("userId", _currentContext.UserId);
-        results.Add("OrgIds", _currentContext.Organizations?.Select(o => o.Id).ToList());
-
         var values = _client.AllFlagsState(BuildContext());
         if (values.Valid)
         {


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other
```

## Objective

Adds feature flag context to config response. This is useful for debugging purposes.

Question: Is there a reason to consider this sensitive? It uses the same bearer token to, say, retrieve full sync data, so all information is retrievable through other endpoints.


## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


<!-- greptile_comment -->

## Greptile Summary

This pull request adds feature flag context to the configuration response, including user ID and organization IDs, to enhance debugging capabilities.

- Added `GetFlagContext()` method to `IFeatureService` interface and implemented in `LaunchDarklyFeatureService`
- Modified `ConfigController` to include feature flag context in `ConfigResponseModel`
- Updated `ConfigResponseModel` to incorporate new `FeatureFlagContext` struct
- Introduced new tests in `LaunchDarklyFeatureServiceTests` for authenticated and unauthenticated user scenarios
- Consider potential security implications of exposing user and organization IDs in the config response

<!-- /greptile_comment -->