### PR TITLE
[PM-6170] Explore making responses required and nullable

### DIFF
--- a/src/Api/SecretsManager/Models/Response/BaseSecretResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/BaseSecretResponseModel.cs
@@ -1,4 +1,7 @@
-﻿using Bit.Core.Models.Api;
+﻿#nullable enable
+
+using System.ComponentModel.DataAnnotations;
+using Bit.Core.Models.Api;
 using Bit.Core.SecretsManager.Entities;
 
 namespace Bit.Api.SecretsManager.Models.Response;
@@ -24,29 +27,25 @@ public class BaseSecretResponseModel : ResponseModel
         Projects = secret.Projects?.Select(p => new SecretResponseInnerProject(p));
     }
 
-    public BaseSecretResponseModel(string objectName = _objectName) : base(objectName)
-    {
-    }
+    [Required]
+    public Guid Id { get; }
 
-    public BaseSecretResponseModel() : base(_objectName)
-    {
-    }
+    [Required]
+    public Guid OrganizationId { get; }
 
-    public Guid Id { get; set; }
+    public string? Key { get; }
 
-    public Guid OrganizationId { get; set; }
+    public string? Value { get; }
 
-    public string Key { get; set; }
+    public string? Note { get; }
 
-    public string Value { get; set; }
+    [Required]
+    public DateTime CreationDate { get; }
 
-    public string Note { get; set; }
+    [Required]
+    public DateTime RevisionDate { get; }
 
-    public DateTime CreationDate { get; set; }
-
-    public DateTime RevisionDate { get; set; }
-
-    public IEnumerable<SecretResponseInnerProject> Projects { get; set; }
+    public IEnumerable<SecretResponseInnerProject>? Projects { get; init; }
 
     public class SecretResponseInnerProject
     {

--- a/src/Api/SecretsManager/Models/Response/BaseSecretResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/BaseSecretResponseModel.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using System.ComponentModel.DataAnnotations;
 using Bit.Core.Models.Api;
 using Bit.Core.SecretsManager.Entities;
 
@@ -27,10 +26,8 @@ public class BaseSecretResponseModel : ResponseModel
         Projects = secret.Projects?.Select(p => new SecretResponseInnerProject(p));
     }
 
-    [Required]
     public Guid Id { get; }
 
-    [Required]
     public Guid OrganizationId { get; }
 
     public string? Key { get; }
@@ -39,10 +36,8 @@ public class BaseSecretResponseModel : ResponseModel
 
     public string? Note { get; }
 
-    [Required]
     public DateTime CreationDate { get; }
 
-    [Required]
     public DateTime RevisionDate { get; }
 
     public IEnumerable<SecretResponseInnerProject>? Projects { get; init; }

--- a/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
+++ b/src/Api/SecretsManager/Models/Response/SecretResponseModel.cs
@@ -12,10 +12,6 @@ public class SecretResponseModel : BaseSecretResponseModel
         Write = write;
     }
 
-    public SecretResponseModel() : base(_objectName)
-    {
-    }
-
     public bool Read { get; set; }
 
     public bool Write { get; set; }

--- a/src/Api/Utilities/ServiceCollectionExtensions.cs
+++ b/src/Api/Utilities/ServiceCollectionExtensions.cs
@@ -71,6 +71,7 @@ public static class ServiceCollectionExtensions
             // config.UseReferencedDefinitionsForEnums();
 
             config.SchemaFilter<EnumSchemaFilter>();
+            config.SchemaFilter<RequireNotNullableSchemaFilter>();
 
             var apiFilePath = Path.Combine(AppContext.BaseDirectory, "Api.xml");
             config.IncludeXmlComments(apiFilePath, true);

--- a/src/SharedWeb/Swagger/RequireNotNullableSchemaFilter.cs
+++ b/src/SharedWeb/Swagger/RequireNotNullableSchemaFilter.cs
@@ -1,0 +1,66 @@
+﻿using System.Reflection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Bit.SharedWeb.Swagger;
+
+/// <summary>
+///
+/// </summary>
+/// <remarks>
+/// Credits: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2036#issuecomment-894015122
+/// </remarks>
+public class RequireNotNullableSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (schema.Properties == null)
+        {
+            return;
+        }
+
+        FixNullableProperties(schema, context);
+
+        var notNullableProperties = schema
+            .Properties
+            .Where(x => !x.Value.Nullable && x.Value.Default == default && !schema.Required.Contains(x.Key))
+            .ToList();
+
+        foreach (var property in notNullableProperties)
+        {
+            schema.Required.Add(property.Key);
+        }
+    }
+
+    /// <summary>
+    /// Option "SupportNonNullableReferenceTypes" not working with complex types ({ "type": "object" }),
+    /// so they always have "Nullable = false",
+    /// see method "SchemaGenerator.GenerateSchemaForMember"
+    /// </summary>
+    private static void FixNullableProperties(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        foreach (var property in schema.Properties)
+        {
+            var field = context.Type
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(x =>
+                    string.Equals(x.Name, property.Key, StringComparison.InvariantCultureIgnoreCase));
+
+            if (field == null)
+            {
+                continue;
+            }
+
+            var fieldType = field switch
+            {
+                FieldInfo fieldInfo => fieldInfo.FieldType,
+                PropertyInfo propertyInfo => propertyInfo.PropertyType,
+                _ => throw new NotSupportedException(),
+            };
+
+            property.Value.Nullable = fieldType.IsValueType
+                ? Nullable.GetUnderlyingType(fieldType) != null
+                : !field.IsNonNullableReferenceType();
+        }
+    }
+}


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Explore if we can annotate required fields in responses. We could perhaps take advantage of nullable fields instead but that would require a custom filter and Open API separates nullable from required

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


<!-- greptile_comment -->

## Greptile Summary

This pull request enhances type safety and API documentation by introducing nullable reference types and a custom schema filter for OpenAPI in the grepdemos/server repository.

- Added `RequireNotNullableSchemaFilter` in `src/SharedWeb/Swagger/RequireNotNullableSchemaFilter.cs` to improve OpenAPI schema generation for non-nullable properties
- Modified `src/Api/SecretsManager/Models/Response/BaseSecretResponseModel.cs` to use nullable reference types and make properties read-only where appropriate
- Removed parameterless constructor from `src/Api/SecretsManager/Models/Response/SecretResponseModel.cs`, potentially impacting default initialization
- Updated Swagger configuration in `src/Api/Utilities/ServiceCollectionExtensions.cs` to include the new schema filter for enhanced API documentation

<!-- /greptile_comment -->