### PR TITLE
Added groupings for Auth dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -74,6 +74,16 @@
       "reviewers": ["team:team-auth-dev"]
     },
     {
+      "matchPackagePatterns": ["^AspNetCoreRateLimit"],
+      "groupName": "AspNetCoreRateLimit",
+      "description": "Group AspNetCoreRateLimit to exclude them from the dotnet monorepo preset"
+    },
+    {
+      "matchPackagePatterns": ["^Microsoft.Azure.Cosmos"],
+      "groupName": "Microsoft.Azure.Cosmos",
+      "description": "Group Microsoft.Azure.Cosmos to exclude them from the dotnet monorepo preset"
+    },
+    {
       "matchPackageNames": [
         "AutoFixture.AutoNSubstitute",
         "AutoFixture.Xunit2",


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [X] Other
```

## Objective

Group dependent dependencies for Auth team.

## Code changes

* **renovate.json:** Added groups for dependent packages.

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


<!-- greptile_comment -->

## Greptile Summary

This pull request updates the renovate.json configuration to improve dependency management for the Auth team by grouping specific packages.

- Added grouping for AspNetCoreRateLimit packages in `.github/renovate.json`
- Added grouping for Microsoft.Azure.Cosmos packages in `.github/renovate.json`
- Both new groups are excluded from the dotnet monorepo preset
- Changes aim to streamline dependency updates for the Auth team

<!-- /greptile_comment -->