### PR TITLE
Add opentelemetry

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -105,6 +105,18 @@ services:
       - "${IDENTITY_PROXY_PORT}:${IDENTITY_PROXY_PORT}"
     profiles:
       - proxy
+  
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    environment:
+      COLLECTOR_OTLP_ENABLED: true
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    profiles:
+      - jaeger
 
 volumes:
   edgesql_dev_data:

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -199,6 +199,7 @@ public class Startup
         {
             config.Conventions.Add(new ApiExplorerGroupConvention());
             config.Conventions.Add(new PublicApiControllersModelConvention());
+            config.Filters.Add(new TracingAttribute()); // Add tracing to controller actions and results
         });
 
         services.AddSwagger(globalSettings);
@@ -217,10 +218,14 @@ public class Startup
         IWebHostEnvironment env,
         IHostApplicationLifetime appLifetime,
         GlobalSettings globalSettings,
-        ILogger<Startup> logger)
+        ILogger<Startup> logger,
+        IServiceProvider serviceProvider)
     {
         IdentityModelEventSource.ShowPII = true;
         app.UseSerilog(env, appLifetime, globalSettings);
+
+        // Middleware telemetry
+        DiagnosticsHelpers.AddMiddlewareDiagnostics(serviceProvider);
 
         // Add general security headers
         app.UseMiddleware<SecurityHeadersMiddleware>();

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.1.6" />
     <PackageReference Include="MailKit" Version="4.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.20" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="4.2.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
@@ -42,6 +43,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.31" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
     <PackageReference Include="Quartz" Version="3.9.0" />
     <PackageReference Include="SendGrid" Version="9.29.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />

--- a/src/Core/Utilities/TracingAttribute.cs
+++ b/src/Core/Utilities/TracingAttribute.cs
@@ -1,0 +1,71 @@
+#nullable enable
+
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Core.Utilities;
+
+public class TracingAttribute : ActionFilterAttribute
+{
+    private Activity? _actionActivity;
+    private Activity? _resultActivity;
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        var activitySource = context.HttpContext.RequestServices.GetService<ActivitySource>();
+
+        if (activitySource == null)
+        {
+            return;
+        }
+
+        var activityName = $"{context.ActionDescriptor.DisplayName}_action";
+        _actionActivity = activitySource.StartActivity(activityName, ActivityKind.Server);
+    }
+
+    public override void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (_actionActivity == null)
+        {
+            return;
+        }
+
+        if (context.Exception != null)
+        {
+            _actionActivity.AddTag("exception", context.Exception.ToString());
+            _actionActivity.AddTag("exceptionStackTrace", context.Exception.StackTrace);
+        }
+
+        _actionActivity.Stop();
+    }
+
+    public override void OnResultExecuting(ResultExecutingContext context)
+    {
+        var activitySource = context.HttpContext.RequestServices.GetService<ActivitySource>();
+
+        if (activitySource == null)
+        {
+            return;
+        }
+
+        var activityName = $"{context.ActionDescriptor.DisplayName}_result";
+        _resultActivity = activitySource.StartActivity(activityName, ActivityKind.Server);
+    }
+
+    public override void OnResultExecuted(ResultExecutedContext context)
+    {
+        if (_resultActivity == null)
+        {
+            return;
+        }
+
+        if (context.Exception != null)
+        {
+            _resultActivity.AddTag("exception", context.Exception.ToString());
+            _resultActivity.AddTag("exceptionStackTrace", context.Exception.StackTrace);
+        }
+
+        _resultActivity.Stop();
+    }
+}

--- a/src/EventsProcessor/Properties/launchSettings.json
+++ b/src/EventsProcessor/Properties/launchSettings.json
@@ -20,6 +20,14 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "EventsProcessor-SelfHost": {
+      "commandName": "Project",
+      "applicationUrl": "http://localhost:54104/",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "developSelfHosted": "true"
+      }
     }
   }
 }

--- a/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
@@ -7,6 +7,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.18" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
       <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
       <PackageReference Include="linq2db.EntityFrameworkCore" Version="7.7.0" />
     </ItemGroup>

--- a/src/SharedWeb/Health/DiagnosticsConfig.cs
+++ b/src/SharedWeb/Health/DiagnosticsConfig.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics;
+using Bit.Core.Settings;
+
+namespace Bit.SharedWeb.Health;
+
+public class DiagnosticsConfig
+{
+    public string ServiceName { get; }
+    public ActivitySource ActivitySource { get; }
+
+    public static DiagnosticsConfig For(GlobalSettings globalSettings)
+    {
+        return new DiagnosticsConfig(globalSettings);
+    }
+
+    private DiagnosticsConfig(GlobalSettings globalSettings)
+    {
+        ServiceName = globalSettings.ProjectName ?? "Bitwarden";
+        ActivitySource = new ActivitySource(ServiceName);
+    }
+}

--- a/src/SharedWeb/Health/MiddlewareAnalysisDiagnosticAdapter.cs
+++ b/src/SharedWeb/Health/MiddlewareAnalysisDiagnosticAdapter.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DiagnosticAdapter;
+
+namespace Bit.SharedWeb.Health;
+
+public class MiddlewareAnalysisDiagnosticAdapter
+{
+    private readonly ActivitySource _activitySource;
+    private readonly ConcurrentDictionary<string, Activity> _activities = new();
+
+    public MiddlewareAnalysisDiagnosticAdapter(ActivitySource activitySource)
+    {
+        _activitySource = activitySource;
+    }
+
+    [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareStarting")]
+    public void OnMiddlewareStarting(HttpContext httpContext, string name, Guid instance, long timestamp)
+    {
+        if (name == "Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware")
+        {
+            return;
+        }
+
+        if (_activitySource.StartActivity(name, ActivityKind.Server) is Activity activity)
+        {
+            _activities[name] = activity;
+        }
+    }
+
+    [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareException")]
+    public void OnMiddlewareException(Exception exception, HttpContext httpContext, string name, Guid instance, long timestamp, long duration)
+    {
+        if (name == "Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware" || !_activities.ContainsKey(name))
+        {
+            return;
+        }
+        _activities[name].AddTag("exception", exception.ToString());
+        _activities[name].AddTag("exceptionStackTrace", exception.StackTrace);
+
+        _activities[name].Stop();
+    }
+
+    [DiagnosticName("Microsoft.AspNetCore.MiddlewareAnalysis.MiddlewareFinished")]
+    public void OnMiddlewareFinished(HttpContext httpContext, string name, Guid instance, long timestamp, long duration)
+    {
+        if (name == "Microsoft.AspNetCore.MiddlewareAnalysis.AnalysisMiddleware" || !_activities.ContainsKey(name))
+        {
+            return;
+        }
+        _activities[name].Stop();
+    }
+
+}

--- a/src/SharedWeb/SharedWeb.csproj
+++ b/src/SharedWeb/SharedWeb.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />

--- a/src/SharedWeb/SharedWeb.csproj
+++ b/src/SharedWeb/SharedWeb.csproj
@@ -10,4 +10,10 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+    </ItemGroup>
+
 </Project>

--- a/src/SharedWeb/Utilities/DiagnosticsHelpers.cs
+++ b/src/SharedWeb/Utilities/DiagnosticsHelpers.cs
@@ -1,0 +1,18 @@
+#nullable enable
+
+using System.Diagnostics;
+using Bit.SharedWeb.Health;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.SharedWeb.Utilities;
+
+public static class DiagnosticsHelpers
+{
+    public static void AddMiddlewareDiagnostics(IServiceProvider serviceProvider)
+    {
+        var listener = serviceProvider.GetRequiredService<DiagnosticListener>();
+        var activitySource = serviceProvider.GetRequiredService<ActivitySource>();
+
+        listener.SubscribeWithAdapter(new MiddlewareAnalysisDiagnosticAdapter(activitySource));
+    }
+}

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ using Bit.Core.Vault;
 using Bit.Core.Vault.Services;
 using Bit.Infrastructure.Dapper;
 using Bit.Infrastructure.EntityFramework;
+using Bit.SharedWeb.Health;
 using DnsClient;
 using IdentityModel;
 using LaunchDarkly.Sdk.Server;
@@ -57,6 +58,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Serilog.Context;
 using StackExchange.Redis;
 using NoopRepos = Bit.Core.Repositories.Noop;
@@ -235,6 +238,16 @@ public static class ServiceCollectionExtensions
         services.AddWebAuthn(globalSettings);
         // Required for HTTP calls
         services.AddHttpClient();
+        // Required for open telemetry
+        var diagnosticsConfig = DiagnosticsConfig.For(globalSettings);
+        services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
+        tracerProviderBuilder
+            .AddSource(diagnosticsConfig.ActivitySource.Name)
+            .ConfigureResource(resource => resource
+                .AddService(diagnosticsConfig.ServiceName))
+            .AddAspNetCoreInstrumentation()
+            .AddOtlpExporter());
+
 
         services.AddSingleton<IStripeAdapter, StripeAdapter>();
         services.AddSingleton<Braintree.IBraintreeGateway>((serviceProvider) =>

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.MiddlewareAnalysis;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Azure.Cosmos.Fluent;
 using Microsoft.Extensions.Caching.Cosmos;
@@ -238,16 +239,22 @@ public static class ServiceCollectionExtensions
         services.AddWebAuthn(globalSettings);
         // Required for HTTP calls
         services.AddHttpClient();
-        // Required for open telemetry
-        var diagnosticsConfig = DiagnosticsConfig.For(globalSettings);
-        services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
-        tracerProviderBuilder
-            .AddSource(diagnosticsConfig.ActivitySource.Name)
-            .ConfigureResource(resource => resource
-                .AddService(diagnosticsConfig.ServiceName))
-            .AddAspNetCoreInstrumentation()
-            .AddOtlpExporter());
 
+        // Add open telemetry
+        var diagnosticsConfig = DiagnosticsConfig.For(globalSettings);
+        services.AddSingleton(diagnosticsConfig.ActivitySource);
+        services.AddMiddlewareAnalysis();
+        services.Insert(0, ServiceDescriptor.Transient<IStartupFilter, AnalysisStartupFilter>()); // Insert at beginning to catch all middleware
+        services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
+                tracerProviderBuilder
+                    .AddSource(diagnosticsConfig.ActivitySource.Name)
+                    .ConfigureResource(resource => resource
+                        .AddService(diagnosticsConfig.ServiceName))
+                    .AddAspNetCoreInstrumentation()
+                    .AddSqlClientInstrumentation()
+                    .AddEntityFrameworkCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter());
 
         services.AddSingleton<IStripeAdapter, StripeAdapter>();
         services.AddSingleton<Braintree.IBraintreeGateway>((serviceProvider) =>


### PR DESCRIPTION
## Type of change

<!-- (mark with an `X`) -->

```
- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other
```

## Objective
Adds opentelemetry-based tracing to server projects. Note: tracing is used exclusively as a system profiler to aid in performance optimizations, not intended to trace usage at all. Please let me know if you find some leaked PII in here!



## Code changes

* **launch.json/tasks.json/launchSettings.json** Include Events project in builds, correct the port for events processor self host to be consistent with visual studio build settings and pattern for self-host version of other project (it was previously using the Events port by mistake).
* **docker-compose**: include jaeger as a tool to analyze tracing
* **api/startup**: Add tracing attribute to controller action execution. Turn on middleware telemetry to monitor execution of middlewares
* **tracingAttribute**: Logs tracing even at begin and end of action execution as well as wrapping result processing
* **entityFramework.csproj**: include EF-specific opentelemetry package
* **DiagnosticsConfig**: helper class to configure activity and service information in shared service configuration helpers.
* **MiddlewareAnalysisDiagnosticsHelper**: The idea behind this is to wrap all middleware with trace activities to track their execution time -- much like the controller action wrapping done by the `TracingAttribute`. It works OK, but the library it relies on, [Microsoft.Extensions.MiddlewareAnalysis](https://www.nuget.org/packages/Microsoft.AspNetCore.MiddlewareAnalysis/8.0.0-rc.1.23421.29), is poorly documented and seems to be long-forgotten. Sometimes it seems to randomly miss middlewares, but It certainly catches more than if we didn't have it...
* **diagnosticsHelpers**: static class to add configuration helpers for diagnostics purposes
* **serviceCollectionExtension**: Add openetelemetry and diagnostic event emissions listened to by `MiddlewareAnalysisDiagnosticsHelper`

## Before you submit

- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- If making database changes - make sure you also update Entity Framework queries and/or migrations
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


<!-- greptile_comment -->

## Greptile Summary

This pull request introduces OpenTelemetry-based tracing to the server projects, focusing on system profiling for performance optimization without tracking user-specific data.

- Added Jaeger service in `docker-compose.yml` for distributed tracing analysis
- Implemented `TracingAttribute` in `src/Core/Utilities/TracingAttribute.cs` to wrap controller actions and results with tracing activities
- Created `DiagnosticsConfig` in `src/SharedWeb/Health/DiagnosticsConfig.cs` to configure ActivitySource based on project name
- Introduced `MiddlewareAnalysisDiagnosticAdapter` in `src/SharedWeb/Health/MiddlewareAnalysisDiagnosticAdapter.cs` for middleware execution tracing
- Modified `src/Api/Startup.cs` to integrate tracing and middleware telemetry in the application pipeline

<!-- /greptile_comment -->