### PR TITLE
Added workflow to apply needs-qa label on creation of PRs to master

### DIFF
--- a/.github/workflows/label-issue-pull-request.yml
+++ b/.github/workflows/label-issue-pull-request.yml
@@ -1,0 +1,23 @@
+# Runs on creation of Pull Requests
+# If the PR destination branch is master, add a needs-qa label
+---
+name: Label Issue Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened # Check when PR is opened
+    paths-ignore:
+      - .github/workflows/** # We don't need QA on workflow changes
+    branches:
+      - 'master' # We only want to check when PRs target master
+
+jobs:
+  add-needs-qa-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label to pull request
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          add-labels: "needs-qa"


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
For PRs against `master`, we want to enforce a `needs-qa` label.  We currently have an `enforce-labels` action that will prevent merging if the `needs-qa` label exists.  Currently we rely on the engineer to remember to add it when they create the PR.  This action will run on PR creation and automatically add the label.

The equivalent action is already in place on the `clients` repo.

## Code changes

* **label-issue-pull-request.yml:** New workflow to apply the `needs-qa` label.

## Before you submit
- Please check for formatting errors (`dotnet format --verify-no-changes`) (required)
- Please add **unit tests** where it makes sense to do so (encouraged but not required)
- If this change requires a **documentation update** - notify the documentation team
- If this change has particular **deployment requirements** - notify the DevOps team


<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new GitHub Actions workflow to automatically apply the 'needs-qa' label to pull requests targeting the master branch, complementing the existing enforce-labels workflow.

- Added `.github/workflows/label-issue-pull-request.yml` to automatically label PRs targeting master
- Workflow triggers on PR creation, excluding changes to workflow files
- Uses `andymckay/labeler` action to apply 'needs-qa' label for non-fork PRs
- Complements existing `enforce-labels.yml` workflow, which prevents merging PRs with 'needs-qa' label
- Automates a manual step, reducing the risk of engineers forgetting to add the label

<!-- /greptile_comment -->